### PR TITLE
Fixing flaky test

### DIFF
--- a/core/test/Lender.t.sol
+++ b/core/test/Lender.t.sol
@@ -145,6 +145,7 @@ contract LenderTest is Test {
     }
 
     function test_depositMultipleDestinations(uint112 amountA, uint112 amountB, address toA, address toB) public {
+        if (toA == toB) toB = address(toA) == address(0) ? address(1) : address(0);
         if (uint256(amountA) + uint256(amountB) > type(uint112).max) {
             amountA = amountA / 2;
             amountB = amountB / 2;
@@ -155,6 +156,7 @@ contract LenderTest is Test {
             vm.expectRevert(bytes("Aloe: 0 shares"));
             lender.deposit(amountA, toA);
         } else lender.deposit(amountA, toA);
+
         if (amountB == 0) {
             vm.expectRevert(bytes("Aloe: 0 shares"));
             lender.deposit(amountB, toB);

--- a/core/test/Lender.t.sol
+++ b/core/test/Lender.t.sol
@@ -145,12 +145,13 @@ contract LenderTest is Test {
     }
 
     function test_depositMultipleDestinations(uint112 amountA, uint112 amountB, address toA, address toB) public {
-        if (toA == toB) toB = address(toA) == address(0) ? address(1) : address(0);
+        if (toA == toB) return;
+
         if (uint256(amountA) + uint256(amountB) > type(uint112).max) {
             amountA = amountA / 2;
             amountB = amountB / 2;
         }
-        
+
         deal(address(asset), address(lender), amountA + amountB);
         if (amountA == 0) {
             vm.expectRevert(bytes("Aloe: 0 shares"));


### PR DESCRIPTION
As the title suggests, I noticed a test would sometimes fail, and when I looked into it, I noticed it failed when `toA` and `toB` were the same value. To fix it, I added an additional check that makes sure they are different, as the rest of the logic in the test depends on them being different. Furthermore, I think adding more tests around the case where the multiple destinations are actually the same destination would be worthwhile.