### PR TITLE
Revamp ERC20 fuzz tests

### DIFF
--- a/core/test/LenderERC20.t.sol
+++ b/core/test/LenderERC20.t.sol
@@ -24,15 +24,35 @@ contract LenderERC20Test is Test {
     Lender lender;
 
     function setUp() public {
-        asset = new MockERC20("Token", "TKN", 18);
+        asset = new MockERC20("Test Token", "TKN", 18);
         lender = deploySingleLender(asset, address(2), new RateModel());
     }
 
-    function test_canTransferUpToBalance(address from, address to, uint112 balance, uint112 shares) public {
-        if (balance < shares) (balance, shares) = (shares, balance);
+    function test_name() public {
+        assertEq(lender.name(), "Aloe II Test Token");
+    }
 
+    function test_symbol() public {
+        assertEq(lender.symbol(), "TKN+");
+    }
+
+    function test_decimals() public {
+        assertEq(lender.decimals(), asset.decimals());
+    }
+
+    function test_transfer(address from, address to, uint256 shares, uint112 balance) public {
         deal(address(lender), from, balance);
 
+        // SHOULD throw if `msg.sender` does not have enough tokens to spend
+        if (shares > balance) {
+            vm.prank(from);
+            vm.expectRevert(bytes(""));
+            lender.transfer(to, shares);
+
+            shares = shares % (uint256(balance) + 1);
+        }
+
+        // Transfers amount of tokens to address `to` and MUST fire the `Transfer` event
         vm.prank(from);
         vm.expectEmit(true, true, false, true, address(lender));
         emit Transfer(from, to, shares);
@@ -46,28 +66,144 @@ contract LenderERC20Test is Test {
         }
     }
 
-    function test_cannotTransferMoreThanBalance(address from, address to, uint112 balance, uint112 shares) public {
-        vm.assume(balance != shares);
-        if (balance > shares) (balance, shares) = (shares, balance);
-
+    function test_transferFrom(
+        address spender,
+        address from,
+        address to,
+        uint256 shares,
+        uint112 balance,
+        uint256 allowance
+    ) public {
         deal(address(lender), from, balance);
 
         vm.prank(from);
-        vm.expectRevert(bytes(""));
-        lender.transfer(to, shares);
+        lender.approve(spender, allowance);
+
+        // SHOULD throw unless `from` has deliberately authorized the `spender`
+        if (shares > balance || shares > allowance) {
+            vm.prank(spender);
+            vm.expectRevert();
+            lender.transferFrom(from, to, shares);
+
+            if (shares > balance) shares = shares % (uint256(balance) + 1);
+            if (shares > allowance) shares = shares % (allowance + 1);
+        }
+
+        // Transfers amount of tokens from address `from` and to address `to` and MUST fire the `Transfer` event
+        vm.prank(spender);
+        vm.expectEmit(true, true, false, true, address(lender));
+        emit Transfer(from, to, shares);
+        assertTrue(lender.transferFrom(from, to, shares));
+
+        if (from == to) {
+            assertEq(lender.balanceOf(from), balance);
+        } else {
+            assertEq(lender.balanceOf(from), balance - shares);
+            assertEq(lender.balanceOf(to), shares);
+        }
+
+        if (allowance == type(uint256).max) {
+            assertEq(lender.allowance(from, spender), type(uint256).max);
+        } else {
+            assertEq(lender.allowance(from, spender), allowance - shares);
+        }
     }
 
-    function test_cannotTransferOthersTokens(address from, address to, uint112 shares) public {
-        vm.assume(from != address(this));
-        vm.assume(shares != 0);
+    function test_approve(address from, address spender, uint256 amount) public {
+        vm.prank(from);
+        vm.expectEmit(true, true, false, true, address(lender));
+        emit Approval(from, spender, amount);
+        assertTrue(lender.approve(spender, amount));
 
-        deal(address(lender), from, shares);
-
-        vm.expectRevert(bytes(""));
-        lender.transfer(to, shares);
+        assertEq(lender.allowance(from, spender), amount);
     }
 
-    function test_cannotTransferIfFromAssociatedWithCourier(address from, address to, uint112 shares, uint32 id) public {
+    function test_permit(uint248 key, address spender, uint256 shares, uint256 nonce) public {
+        vm.assume(key != 0);
+        vm.assume(nonce != type(uint256).max);
+
+        address owner = vm.addr(key);
+        stdstore.target(address(lender)).sig("nonces(address)").with_key(owner).depth(0).checked_write(nonce);
+
+        (uint8 v, bytes32 r, bytes32 s) = _sign(key, owner, spender, shares, nonce, block.timestamp);
+
+        lender.permit(owner, spender, shares, block.timestamp, v, r, s);
+        assertEq(lender.allowance(owner, spender), shares);
+        assertEq(lender.nonces(owner), nonce + 1);
+    }
+
+    function test_permitChecksDeadline(
+        uint248 key,
+        address spender,
+        uint256 shares,
+        uint256 nonce,
+        uint256 deadline
+    ) public {
+        vm.assume(key != 0);
+        vm.assume(nonce != type(uint256).max);
+        deadline = deadline % block.timestamp;
+
+        address owner = vm.addr(key);
+        stdstore.target(address(lender)).sig("nonces(address)").with_key(owner).depth(0).checked_write(nonce);
+
+        (uint8 v, bytes32 r, bytes32 s) = _sign(key, owner, spender, shares, nonce, deadline);
+
+        vm.expectRevert(bytes("Aloe: permit expired"));
+        lender.permit(owner, spender, shares, deadline, v, r, s);
+    }
+
+    function test_permitChecksSignature(uint248 key, address spender, uint256 shares, uint256 nonce) public {
+        vm.assume(key != 0);
+        vm.assume(nonce != type(uint256).max);
+
+        address owner = vm.addr(key);
+        stdstore.target(address(lender)).sig("nonces(address)").with_key(owner).depth(0).checked_write(nonce);
+
+        (uint8 v, bytes32 r, bytes32 s) = _sign(uint256(key) + 1, owner, spender, shares, nonce, block.timestamp);
+
+        vm.expectRevert(bytes("Aloe: permit invalid"));
+        lender.permit(owner, spender, shares, block.timestamp, v, r, s);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            HELP THE FUZZER
+    //////////////////////////////////////////////////////////////*/
+
+    function test_transfer0(address from, address to, uint112 balance) public {
+        // Transfers of 0 values MUST be treated as normal transfers and fire the `Transfer` event
+        test_transfer(from, to, 0, balance);
+    }
+
+    function test_transferFrom0(address spender, address from, address to, uint112 balance, uint256 allowance) public {
+        // Transfers of 0 values MUST be treated as normal transfers and fire the `Transfer` event
+        test_transferFrom(spender, from, to, 0, balance, allowance);
+    }
+
+    function test_transferFromIsConstrainedByBalance(
+        address spender,
+        address from,
+        address to,
+        uint256 shares,
+        uint112 balance
+    ) public {
+        test_transferFrom(spender, from, to, shares, balance, type(uint256).max);
+    }
+
+    function test_transferFromIsConstrainedByAllowance(
+        address spender,
+        address from,
+        address to,
+        uint256 shares,
+        uint112 allowance
+    ) public {
+        test_transferFrom(spender, from, to, shares, type(uint112).max, allowance);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                             SPECIAL CASES
+    //////////////////////////////////////////////////////////////*/
+
+    function test_cannotTransferIfSenderHasCourier(address from, address to, uint112 shares, uint32 id) public {
         vm.assume(id != 0);
 
         uint256 value = (uint256(id) << 224) + shares;
@@ -78,162 +214,48 @@ contract LenderERC20Test is Test {
         lender.transfer(to, shares);
     }
 
-    function test_cannotTransferIfToAssociatedWithCourier(address from, address to, uint112 shares, uint32 id) public {
+    function test_cannotTransferIfRecipientHasCourier(address from, address to, uint112 shares, uint32 id) public {
         vm.assume(id != 0);
 
         stdstore.target(address(lender)).sig("balances(address)").with_key(from).depth(0).checked_write(shares);
-        stdstore.target(address(lender)).sig("balances(address)").with_key(to).depth(0).checked_write(uint256(id) << 224);
+        stdstore.target(address(lender)).sig("balances(address)").with_key(to).depth(0).checked_write(
+            uint256(id) << 224
+        );
 
         vm.prank(from);
         vm.expectRevert(bytes(""));
         lender.transfer(to, shares);
     }
 
-    function test_canApprove(address from, address spender, uint256 amount) public {
-        vm.prank(from);
-        vm.expectEmit(true, true, false, true, address(lender));
-        emit Approval(from, spender, amount);
-        assertTrue(lender.approve(spender, amount));
+    /// @dev Yes, I'm aware this is a silly test. It's fine.
+    function test_transferReliesOnSender(address from, address to, uint112 shares) public {
+        vm.assume(from != address(this));
+        vm.assume(shares != 0);
 
-        assertEq(lender.allowance(from, spender), amount);
+        deal(address(lender), from, shares);
+
+        vm.expectRevert(bytes("")); // because we didn't `vm.prank(from)`
+        lender.transfer(to, shares);
     }
 
-    function test_canTransferFromUpToAllowance(address from, address to, uint112 shares, uint112 allowance) public {
-        if (allowance < shares) (allowance, shares) = (shares, allowance);
-
-        deal(address(lender), from, type(uint112).max);
-
-        vm.prank(from);
-        lender.approve(address(this), allowance);
-
-        vm.expectEmit(true, true, false, true, address(lender));
-        emit Transfer(from, to, shares);
-        assertTrue(lender.transferFrom(from, to, shares));
-
-        if (from == to) {
-            assertEq(lender.balanceOf(from), type(uint112).max);
-        } else {
-            assertEq(lender.balanceOf(from), type(uint112).max - shares);
-            assertEq(lender.balanceOf(to), shares);
-            assertEq(lender.allowance(from, address(this)), allowance - shares);
-        }
-    }
-
-    function test_cannotTransferFromMoreThanBalance(address from, address to, uint112 balance, uint112 shares) public {
-        vm.assume(balance != shares);
-        if (balance > shares) (balance, shares) = (shares, balance);
-
-        deal(address(lender), from, balance);
-
-        vm.prank(from);
-        lender.approve(address(this), type(uint256).max);
-
-        vm.expectRevert(bytes(""));
-        lender.transferFrom(from, to, shares);
-    }
-
-    function test_cannotTransferFromMoreThanAllowance(
-        address from,
-        address to,
-        uint112 shares,
-        uint112 allowance
-    ) public {
-        vm.assume(allowance != shares);
-        if (allowance > shares) (allowance, shares) = (shares, allowance);
-
-        deal(address(lender), from, type(uint112).max);
-
-        vm.prank(from);
-        lender.approve(address(this), allowance);
-
-        vm.expectRevert();
-        lender.transferFrom(from, to, shares);
-    }
-
-    function test_canApproveInfinite(address from, address to, uint112 shares) public {
-        vm.assume(from != to);
-
-        deal(address(lender), from, type(uint112).max);
-
-        vm.prank(from);
-        lender.approve(address(this), type(uint256).max);
-
-        assertEq(lender.balanceOf(from), type(uint112).max);
-        lender.transferFrom(from, to, shares);
-        assertEq(lender.balanceOf(from), type(uint112).max - shares);
-        assertEq(lender.balanceOf(to), shares);
-        assertEq(lender.allowance(from, address(this)), type(uint256).max);
-    }
-
-    function test_canPermit(uint256 privateKey, address spender, uint256 amount, uint256 nonce) public {
-        privateKey = privateKey / 2 + 1;
-        address owner = vm.addr(privateKey);
-
-        if (nonce == type(uint256).max) nonce -= 1;
-        stdstore.target(address(lender)).sig("nonces(address)").with_key(owner).depth(0).checked_write(nonce);
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-            privateKey,
-            keccak256(
-                abi.encodePacked(
-                    "\x19\x01",
-                    lender.DOMAIN_SEPARATOR(),
-                    keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, amount, nonce, block.timestamp))
-                )
-            )
-        );
-
-        lender.permit(owner, spender, amount, block.timestamp, v, r, s);
-        assertEq(lender.allowance(owner, spender), amount);
-        assertEq(lender.nonces(owner), nonce + 1);
-    }
-
-    function test_cannotPermitAfterDeadline(uint256 privateKey, address spender, uint256 amount, uint256 nonce) public {
-        privateKey = privateKey / 2 + 1;
-        address owner = vm.addr(privateKey);
-
-        if (nonce == type(uint256).max) nonce -= 1;
-        stdstore.target(address(lender)).sig("nonces(address)").with_key(owner).depth(0).checked_write(nonce);
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-            privateKey,
-            keccak256(
-                abi.encodePacked(
-                    "\x19\x01",
-                    lender.DOMAIN_SEPARATOR(),
-                    keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, amount, nonce, block.timestamp - 1))
-                )
-            )
-        );
-
-        vm.expectRevert(bytes("Aloe: permit expired"));
-        lender.permit(owner, spender, amount, block.timestamp - 1, v, r, s);
-    }
-
-    function test_cannotPermitWithBadSignature(
-        uint256 privateKey,
+    function _sign(
+        uint256 key,
+        address owner,
         address spender,
-        uint256 amount,
-        uint256 nonce
-    ) public {
-        privateKey = privateKey / 2 + 1;
-        address owner = vm.addr(privateKey);
-
-        if (nonce == type(uint256).max) nonce -= 1;
-        stdstore.target(address(lender)).sig("nonces(address)").with_key(owner).depth(0).checked_write(nonce);
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-            privateKey + 1,
-            keccak256(
-                abi.encodePacked(
-                    "\x19\x01",
-                    lender.DOMAIN_SEPARATOR(),
-                    keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, amount, nonce, block.timestamp))
+        uint256 shares,
+        uint256 nonce,
+        uint256 deadline
+    ) private view returns (uint8 v, bytes32 r, bytes32 s) {
+        return
+            vm.sign(
+                key,
+                keccak256(
+                    abi.encodePacked(
+                        "\x19\x01",
+                        lender.DOMAIN_SEPARATOR(),
+                        keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, shares, nonce, deadline))
+                    )
                 )
-            )
-        );
-
-        vm.expectRevert(bytes("Aloe: permit invalid"));
-        lender.permit(owner, spender, amount, block.timestamp, v, r, s);
+            );
     }
 }


### PR DESCRIPTION
We already had pretty thorough fuzz tests for the `Lender`'s conformance to ERC20. This change really just standardizes the test layout to match the stuff I wrote for `Lender` invariants.

Slight coverage increase by testing `name`, `symbol`, and `decimals`

Also, since I re-ordered things, it's probably easier to read the new file in isolation rather than looking at the diff to review.