### PR TITLE
Add ERC4626 fuzz tests

### DIFF
--- a/core/src/Lender.sol
+++ b/core/src/Lender.sol
@@ -137,7 +137,6 @@ contract Lender is Ledger {
         emit Deposit(msg.sender, beneficiary, amount, shares);
     }
 
-    // TODO: We aren't `require`ing that the return value of `deposit` == `shares`. Check it in fuzz tests.
     function mint(uint256 shares, address beneficiary) external returns (uint256 amount) {
         amount = previewMint(shares);
         deposit(amount, beneficiary);
@@ -171,7 +170,6 @@ contract Lender is Ledger {
         emit Withdraw(msg.sender, recipient, owner, amount, shares);
     }
 
-    // TODO: We aren't `require`ing that the return value of `redeem` == `amount`. Check it in fuzz tests.
     function withdraw(uint256 amount, address recipient, address owner) external returns (uint256 shares) {
         shares = previewWithdraw(amount);
         redeem(shares, recipient, owner);

--- a/core/test/LenderERC20.t.sol
+++ b/core/test/LenderERC20.t.sol
@@ -24,15 +24,35 @@ contract LenderERC20Test is Test {
     Lender lender;
 
     function setUp() public {
-        asset = new MockERC20("Token", "TKN", 18);
+        asset = new MockERC20("Test Token", "TKN", 18);
         lender = deploySingleLender(asset, address(2), new RateModel());
     }
 
-    function test_canTransferUpToBalance(address from, address to, uint112 balance, uint112 shares) public {
-        if (balance < shares) (balance, shares) = (shares, balance);
+    function test_name() public {
+        assertEq(lender.name(), "Aloe II Test Token");
+    }
 
+    function test_symbol() public {
+        assertEq(lender.symbol(), "TKN+");
+    }
+
+    function test_decimals() public {
+        assertEq(lender.decimals(), asset.decimals());
+    }
+
+    function test_transfer(address from, address to, uint256 shares, uint112 balance) public {
         deal(address(lender), from, balance);
 
+        // SHOULD throw if `msg.sender` does not have enough tokens to spend
+        if (shares > balance) {
+            vm.prank(from);
+            vm.expectRevert(bytes(""));
+            lender.transfer(to, shares);
+
+            shares = shares % (uint256(balance) + 1);
+        }
+
+        // Transfers amount of tokens to address `to` and MUST fire the `Transfer` event
         vm.prank(from);
         vm.expectEmit(true, true, false, true, address(lender));
         emit Transfer(from, to, shares);
@@ -46,28 +66,144 @@ contract LenderERC20Test is Test {
         }
     }
 
-    function test_cannotTransferMoreThanBalance(address from, address to, uint112 balance, uint112 shares) public {
-        vm.assume(balance != shares);
-        if (balance > shares) (balance, shares) = (shares, balance);
-
+    function test_transferFrom(
+        address spender,
+        address from,
+        address to,
+        uint256 shares,
+        uint112 balance,
+        uint256 allowance
+    ) public {
         deal(address(lender), from, balance);
 
         vm.prank(from);
-        vm.expectRevert(bytes(""));
-        lender.transfer(to, shares);
+        lender.approve(spender, allowance);
+
+        // SHOULD throw unless `from` has deliberately authorized the `spender`
+        if (shares > balance || shares > allowance) {
+            vm.prank(spender);
+            vm.expectRevert();
+            lender.transferFrom(from, to, shares);
+
+            if (shares > balance) shares = shares % (uint256(balance) + 1);
+            if (shares > allowance) shares = shares % (allowance + 1);
+        }
+
+        // Transfers amount of tokens from address `from` and to address `to` and MUST fire the `Transfer` event
+        vm.prank(spender);
+        vm.expectEmit(true, true, false, true, address(lender));
+        emit Transfer(from, to, shares);
+        assertTrue(lender.transferFrom(from, to, shares));
+
+        if (from == to) {
+            assertEq(lender.balanceOf(from), balance);
+        } else {
+            assertEq(lender.balanceOf(from), balance - shares);
+            assertEq(lender.balanceOf(to), shares);
+        }
+
+        if (allowance == type(uint256).max) {
+            assertEq(lender.allowance(from, spender), type(uint256).max);
+        } else {
+            assertEq(lender.allowance(from, spender), allowance - shares);
+        }
     }
 
-    function test_cannotTransferOthersTokens(address from, address to, uint112 shares) public {
-        vm.assume(from != address(this));
-        vm.assume(shares != 0);
+    function test_approve(address from, address spender, uint256 amount) public {
+        vm.prank(from);
+        vm.expectEmit(true, true, false, true, address(lender));
+        emit Approval(from, spender, amount);
+        assertTrue(lender.approve(spender, amount));
 
-        deal(address(lender), from, shares);
-
-        vm.expectRevert(bytes(""));
-        lender.transfer(to, shares);
+        assertEq(lender.allowance(from, spender), amount);
     }
 
-    function test_cannotTransferIfFromAssociatedWithCourier(address from, address to, uint112 shares, uint32 id) public {
+    function test_permit(uint248 key, address spender, uint256 shares, uint256 nonce) public {
+        vm.assume(key != 0);
+        vm.assume(nonce != type(uint256).max);
+
+        address owner = vm.addr(key);
+        stdstore.target(address(lender)).sig("nonces(address)").with_key(owner).depth(0).checked_write(nonce);
+
+        (uint8 v, bytes32 r, bytes32 s) = _sign(key, owner, spender, shares, nonce, block.timestamp);
+
+        lender.permit(owner, spender, shares, block.timestamp, v, r, s);
+        assertEq(lender.allowance(owner, spender), shares);
+        assertEq(lender.nonces(owner), nonce + 1);
+    }
+
+    function test_permitChecksDeadline(
+        uint248 key,
+        address spender,
+        uint256 shares,
+        uint256 nonce,
+        uint256 deadline
+    ) public {
+        vm.assume(key != 0);
+        vm.assume(nonce != type(uint256).max);
+        deadline = deadline % block.timestamp;
+
+        address owner = vm.addr(key);
+        stdstore.target(address(lender)).sig("nonces(address)").with_key(owner).depth(0).checked_write(nonce);
+
+        (uint8 v, bytes32 r, bytes32 s) = _sign(key, owner, spender, shares, nonce, deadline);
+
+        vm.expectRevert(bytes("Aloe: permit expired"));
+        lender.permit(owner, spender, shares, deadline, v, r, s);
+    }
+
+    function test_permitChecksSignature(uint248 key, address spender, uint256 shares, uint256 nonce) public {
+        vm.assume(key != 0);
+        vm.assume(nonce != type(uint256).max);
+
+        address owner = vm.addr(key);
+        stdstore.target(address(lender)).sig("nonces(address)").with_key(owner).depth(0).checked_write(nonce);
+
+        (uint8 v, bytes32 r, bytes32 s) = _sign(uint256(key) + 1, owner, spender, shares, nonce, block.timestamp);
+
+        vm.expectRevert(bytes("Aloe: permit invalid"));
+        lender.permit(owner, spender, shares, block.timestamp, v, r, s);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            HELP THE FUZZER
+    //////////////////////////////////////////////////////////////*/
+
+    function test_transfer0(address from, address to, uint112 balance) public {
+        // Transfers of 0 values MUST be treated as normal transfers and fire the `Transfer` event
+        test_transfer(from, to, 0, balance);
+    }
+
+    function test_transferFrom0(address spender, address from, address to, uint112 balance, uint256 allowance) public {
+        // Transfers of 0 values MUST be treated as normal transfers and fire the `Transfer` event
+        test_transferFrom(spender, from, to, 0, balance, allowance);
+    }
+
+    function test_transferFromIsConstrainedByBalance(
+        address spender,
+        address from,
+        address to,
+        uint256 shares,
+        uint112 balance
+    ) public {
+        test_transferFrom(spender, from, to, shares, balance, type(uint256).max);
+    }
+
+    function test_transferFromIsConstrainedByAllowance(
+        address spender,
+        address from,
+        address to,
+        uint256 shares,
+        uint112 allowance
+    ) public {
+        test_transferFrom(spender, from, to, shares, type(uint112).max, allowance);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                             SPECIAL CASES
+    //////////////////////////////////////////////////////////////*/
+
+    function test_cannotTransferIfSenderHasCourier(address from, address to, uint112 shares, uint32 id) public {
         vm.assume(id != 0);
 
         uint256 value = (uint256(id) << 224) + shares;
@@ -78,162 +214,48 @@ contract LenderERC20Test is Test {
         lender.transfer(to, shares);
     }
 
-    function test_cannotTransferIfToAssociatedWithCourier(address from, address to, uint112 shares, uint32 id) public {
+    function test_cannotTransferIfRecipientHasCourier(address from, address to, uint112 shares, uint32 id) public {
         vm.assume(id != 0);
 
         stdstore.target(address(lender)).sig("balances(address)").with_key(from).depth(0).checked_write(shares);
-        stdstore.target(address(lender)).sig("balances(address)").with_key(to).depth(0).checked_write(uint256(id) << 224);
+        stdstore.target(address(lender)).sig("balances(address)").with_key(to).depth(0).checked_write(
+            uint256(id) << 224
+        );
 
         vm.prank(from);
         vm.expectRevert(bytes(""));
         lender.transfer(to, shares);
     }
 
-    function test_canApprove(address from, address spender, uint256 amount) public {
-        vm.prank(from);
-        vm.expectEmit(true, true, false, true, address(lender));
-        emit Approval(from, spender, amount);
-        assertTrue(lender.approve(spender, amount));
+    /// @dev Yes, I'm aware this is a silly test. It's fine.
+    function test_transferReliesOnSender(address from, address to, uint112 shares) public {
+        vm.assume(from != address(this));
+        vm.assume(shares != 0);
 
-        assertEq(lender.allowance(from, spender), amount);
+        deal(address(lender), from, shares);
+
+        vm.expectRevert(bytes("")); // because we didn't `vm.prank(from)`
+        lender.transfer(to, shares);
     }
 
-    function test_canTransferFromUpToAllowance(address from, address to, uint112 shares, uint112 allowance) public {
-        if (allowance < shares) (allowance, shares) = (shares, allowance);
-
-        deal(address(lender), from, type(uint112).max);
-
-        vm.prank(from);
-        lender.approve(address(this), allowance);
-
-        vm.expectEmit(true, true, false, true, address(lender));
-        emit Transfer(from, to, shares);
-        assertTrue(lender.transferFrom(from, to, shares));
-
-        if (from == to) {
-            assertEq(lender.balanceOf(from), type(uint112).max);
-        } else {
-            assertEq(lender.balanceOf(from), type(uint112).max - shares);
-            assertEq(lender.balanceOf(to), shares);
-            assertEq(lender.allowance(from, address(this)), allowance - shares);
-        }
-    }
-
-    function test_cannotTransferFromMoreThanBalance(address from, address to, uint112 balance, uint112 shares) public {
-        vm.assume(balance != shares);
-        if (balance > shares) (balance, shares) = (shares, balance);
-
-        deal(address(lender), from, balance);
-
-        vm.prank(from);
-        lender.approve(address(this), type(uint256).max);
-
-        vm.expectRevert(bytes(""));
-        lender.transferFrom(from, to, shares);
-    }
-
-    function test_cannotTransferFromMoreThanAllowance(
-        address from,
-        address to,
-        uint112 shares,
-        uint112 allowance
-    ) public {
-        vm.assume(allowance != shares);
-        if (allowance > shares) (allowance, shares) = (shares, allowance);
-
-        deal(address(lender), from, type(uint112).max);
-
-        vm.prank(from);
-        lender.approve(address(this), allowance);
-
-        vm.expectRevert();
-        lender.transferFrom(from, to, shares);
-    }
-
-    function test_canApproveInfinite(address from, address to, uint112 shares) public {
-        vm.assume(from != to);
-
-        deal(address(lender), from, type(uint112).max);
-
-        vm.prank(from);
-        lender.approve(address(this), type(uint256).max);
-
-        assertEq(lender.balanceOf(from), type(uint112).max);
-        lender.transferFrom(from, to, shares);
-        assertEq(lender.balanceOf(from), type(uint112).max - shares);
-        assertEq(lender.balanceOf(to), shares);
-        assertEq(lender.allowance(from, address(this)), type(uint256).max);
-    }
-
-    function test_canPermit(uint256 privateKey, address spender, uint256 amount, uint256 nonce) public {
-        privateKey = privateKey / 2 + 1;
-        address owner = vm.addr(privateKey);
-
-        if (nonce == type(uint256).max) nonce -= 1;
-        stdstore.target(address(lender)).sig("nonces(address)").with_key(owner).depth(0).checked_write(nonce);
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-            privateKey,
-            keccak256(
-                abi.encodePacked(
-                    "\x19\x01",
-                    lender.DOMAIN_SEPARATOR(),
-                    keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, amount, nonce, block.timestamp))
-                )
-            )
-        );
-
-        lender.permit(owner, spender, amount, block.timestamp, v, r, s);
-        assertEq(lender.allowance(owner, spender), amount);
-        assertEq(lender.nonces(owner), nonce + 1);
-    }
-
-    function test_cannotPermitAfterDeadline(uint256 privateKey, address spender, uint256 amount, uint256 nonce) public {
-        privateKey = privateKey / 2 + 1;
-        address owner = vm.addr(privateKey);
-
-        if (nonce == type(uint256).max) nonce -= 1;
-        stdstore.target(address(lender)).sig("nonces(address)").with_key(owner).depth(0).checked_write(nonce);
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-            privateKey,
-            keccak256(
-                abi.encodePacked(
-                    "\x19\x01",
-                    lender.DOMAIN_SEPARATOR(),
-                    keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, amount, nonce, block.timestamp - 1))
-                )
-            )
-        );
-
-        vm.expectRevert(bytes("Aloe: permit expired"));
-        lender.permit(owner, spender, amount, block.timestamp - 1, v, r, s);
-    }
-
-    function test_cannotPermitWithBadSignature(
-        uint256 privateKey,
+    function _sign(
+        uint256 key,
+        address owner,
         address spender,
-        uint256 amount,
-        uint256 nonce
-    ) public {
-        privateKey = privateKey / 2 + 1;
-        address owner = vm.addr(privateKey);
-
-        if (nonce == type(uint256).max) nonce -= 1;
-        stdstore.target(address(lender)).sig("nonces(address)").with_key(owner).depth(0).checked_write(nonce);
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-            privateKey + 1,
-            keccak256(
-                abi.encodePacked(
-                    "\x19\x01",
-                    lender.DOMAIN_SEPARATOR(),
-                    keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, amount, nonce, block.timestamp))
+        uint256 shares,
+        uint256 nonce,
+        uint256 deadline
+    ) private view returns (uint8 v, bytes32 r, bytes32 s) {
+        return
+            vm.sign(
+                key,
+                keccak256(
+                    abi.encodePacked(
+                        "\x19\x01",
+                        lender.DOMAIN_SEPARATOR(),
+                        keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, shares, nonce, deadline))
+                    )
                 )
-            )
-        );
-
-        vm.expectRevert(bytes("Aloe: permit invalid"));
-        lender.permit(owner, spender, amount, block.timestamp, v, r, s);
+            );
     }
 }

--- a/core/test/invariants/ERC4626Harness.sol
+++ b/core/test/invariants/ERC4626Harness.sol
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.17;
+
+import "forge-std/Vm.sol";
+
+import {ERC4626, ERC20} from "solmate/mixins/ERC4626.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+
+import "src/Lender.sol";
+
+contract ERC4626Harness {
+    event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
+
+    event Withdraw(
+        address indexed caller,
+        address indexed receiver,
+        address indexed owner,
+        uint256 assets,
+        uint256 shares
+    );
+
+    Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    ERC4626 immutable VAULT;
+
+    address[] public holders;
+
+    mapping(address => bool) alreadyHolder;
+
+    /*//////////////////////////////////////////////////////////////
+                              CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    constructor(Lender lender) {
+        VAULT = ERC4626(address(lender));
+
+        holders.push(lender.RESERVE());
+        alreadyHolder[lender.RESERVE()] = true;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                  MAIN
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Don't mess with the logic here, things get weird. See https://github.com/foundry-rs/foundry/issues/3806
+    function warp(uint16 elapsedTime) external {
+        uint256 t0 = block.timestamp;
+        uint256 t1 = t0 + elapsedTime;
+        if (elapsedTime > 0) {
+            vm.warp(t1);
+            require(block.timestamp == t1, "warp failed");
+        }
+    }
+
+    function deposit(uint256 amount, address receiver, bool shouldPrepay) public returns (uint256 shares) {
+        amount = amount % (VAULT.maxDeposit(msg.sender) + 1); // TODO: if remove this, could run with reverts allowed
+
+        ERC20 asset = VAULT.asset();
+        uint256 balance = asset.balanceOf(msg.sender);
+
+        // MUST return as close to and no more than the exact amount of shares that would be minted in a `deposit` call
+        shares = VAULT.previewDeposit(amount);
+
+        // Make sure `msg.sender` has enough assets to deposit
+        if (amount > balance) {
+            vm.prank(msg.sender);
+            vm.expectRevert(bytes(shares > 0 ? "TRANSFER_FROM_FAILED" : "Aloe: zero impact"));
+            VAULT.deposit(amount, receiver);
+
+            MockERC20 mock = MockERC20(address(asset));
+            mock.mint(msg.sender, amount - balance);
+            balance = amount;
+        }
+
+        // Collect data
+        uint256 totalAssets = VAULT.totalAssets();
+        // uint256 totalSupply = VAULT.totalSupply();
+        uint256 sharesBefore = VAULT.balanceOf(receiver);
+
+        // Actual action
+        // --> Pre-pay or approve
+        vm.prank(msg.sender);
+        if (shouldPrepay) asset.transfer(address(VAULT), amount); // MAY support an additional flow
+        else asset.approve(address(VAULT), amount); // MUST support EIP-20 `approve`/`transferFrom` flow
+        // --> Make deposit
+        if (shares == 0) {
+            vm.prank(msg.sender);
+            vm.expectRevert(bytes("Aloe: zero impact"));
+            VAULT.deposit(amount, receiver);
+            amount = 0;
+        } else {
+            vm.prank(msg.sender);
+            vm.expectEmit(true, true, false, true, address(VAULT)); // MUST emit `Deposit` event
+            emit Deposit(msg.sender, receiver, amount, shares);
+            require(VAULT.deposit(amount, receiver) == shares, "deposit: incorrect preview");
+        }
+
+        // Assertions
+        require(asset.balanceOf(msg.sender) == balance - amount, "deposit: payment issue");
+        require(VAULT.totalAssets() == totalAssets + amount, "deposit: totalAssets mismatch");
+        // NOTE: This doesn't hold when interest accrues (because shares are minted to reserves)
+        // require(VAULT.totalSupply() == totalSupply + shares, "deposit: totalSupply mismatch");
+        if (receiver != holders[0]) {
+            require(VAULT.balanceOf(receiver) == sharesBefore + shares, "deposit: mint issue");
+        }
+
+        // {HARNESS BOOKKEEPING} Keep holders up-to-date
+        if (!alreadyHolder[receiver]) {
+            holders.push(receiver);
+            alreadyHolder[receiver] = true;
+        }
+    }
+
+    function mint(uint256 shares, address receiver, bool shouldPrepay) public returns (uint256 amount) {
+        shares = shares % (VAULT.maxMint(msg.sender) + 1); // TODO: if remove this, could run with reverts allowed
+
+        ERC20 asset = VAULT.asset();
+        uint256 balance = asset.balanceOf(msg.sender);
+
+        // MUST return as close to and no more than the exact amount of assets that would be deposited in a `mint` call
+        amount = VAULT.previewMint(shares);
+
+        // Make sure `msg.sender` has enough assets to mint
+        if (amount > balance) {
+            vm.prank(msg.sender);
+            vm.expectRevert(bytes(shares > 0 ? "TRANSFER_FROM_FAILED" : "Aloe: zero impact"));
+            VAULT.mint(amount, receiver);
+
+            MockERC20 mock = MockERC20(address(asset));
+            mock.mint(msg.sender, amount - balance);
+            balance = amount;
+        }
+
+        // Collect data
+        uint256 totalAssets = VAULT.totalAssets();
+        uint256 sharesBefore = VAULT.balanceOf(receiver);
+
+        // Actual action
+        // --> Pre-pay or approve
+        vm.prank(msg.sender);
+        if (shouldPrepay) asset.transfer(address(VAULT), amount); // MAY support an additional flow
+        else asset.approve(address(VAULT), amount); // MUST support EIP-20 `approve`/`transferFrom` flow
+        // --> Make mint
+        if (shares == 0) {
+            vm.prank(msg.sender);
+            vm.expectRevert(bytes("Aloe: zero impact"));
+            VAULT.mint(shares, receiver);
+        } else {
+            vm.prank(msg.sender);
+            vm.expectEmit(true, true, false, true, address(VAULT)); // MUST emit `Deposit` event
+            emit Deposit(msg.sender, receiver, amount, shares);
+            require(VAULT.mint(shares, receiver) == amount, "mint: incorrect preview");
+        }
+
+        // Assertions
+        require(asset.balanceOf(msg.sender) == balance - amount, "mint: payment issue");
+        require(VAULT.totalAssets() == totalAssets + amount, "mint: totalAssets mismatch");
+        if (receiver != holders[0]) {
+            require(VAULT.balanceOf(receiver) == sharesBefore + shares, "mint: mint issue");
+        }
+        // NOTE: We don't make assertions about the change in `totalSupply` because when interest accrues,
+        // shares are minted to reserves (separate from the operations being tested).
+
+        // {HARNESS BOOKKEEPING} Keep holders up-to-date
+        if (!alreadyHolder[receiver]) {
+            holders.push(receiver);
+            alreadyHolder[receiver] = true;
+        }
+    }
+
+    function redeem(uint256 shares, address receiver, address owner) public returns (uint256 assets) {
+        // MUST revert if all of `shares` cannot be redeemed
+        uint256 maxRedeem = VAULT.maxRedeem(owner);
+        if (shares > maxRedeem) {
+            vm.prank(msg.sender);
+            vm.expectRevert();
+            VAULT.redeem(shares, receiver, owner);
+
+            shares = shares % (maxRedeem + 1);
+        }
+
+        // SHOULD check `msg.sender` can spend owner funds using allowance
+        if (owner != msg.sender) {
+            vm.prank(msg.sender);
+            vm.expectRevert();
+            VAULT.redeem(shares, receiver, owner);
+
+            vm.prank(owner);
+            VAULT.approve(msg.sender, shares);
+        }
+
+        // Collect data
+        assets = VAULT.previewRedeem(shares);
+        uint256 totalAssets = VAULT.totalAssets();
+        uint256 sharesBefore = VAULT.balanceOf(owner);
+        uint256 assetsBefore = VAULT.asset().balanceOf(receiver);
+
+        // Actual action
+        if (assets == 0) {
+            vm.prank(msg.sender);
+            vm.expectRevert(bytes("Aloe: zero impact"));
+            VAULT.redeem(shares, receiver, owner);
+            shares = 0;
+        } else {
+            vm.prank(msg.sender);
+            vm.expectEmit(true, true, true, true, address(VAULT)); // MUST emit `Withdraw` event
+            emit Withdraw(msg.sender, receiver, owner, assets, shares);
+            require(VAULT.redeem(shares, receiver, owner) == assets, "redeem: incorrect preview");
+        }
+
+        // Assertions
+        require(VAULT.totalAssets() == totalAssets - assets, "redeem: totalAssets mismatch");
+        if (receiver != address(VAULT)) {
+            require(VAULT.asset().balanceOf(receiver) == assetsBefore + assets, "redeem: transfer issue");
+        } else {
+            require(VAULT.asset().balanceOf(receiver) == assetsBefore, "redeem: bad self reference");
+        }
+        if (receiver != holders[0]) {
+            require(VAULT.balanceOf(owner) == sharesBefore - shares, "redeem: burn issue");
+        }
+        // NOTE: We don't make assertions about the change in `totalSupply` because when interest accrues,
+        // shares are minted to reserves (separate from the operations being tested).
+    }
+
+    function withdraw(uint256 assets, address receiver, address owner) public returns (uint256 shares) {
+        // MUST revert if all of `assets` cannot be withdrawn
+        uint256 maxWithdraw = VAULT.maxWithdraw(owner);
+        if (assets > maxWithdraw) {
+            vm.prank(msg.sender);
+            vm.expectRevert();
+            VAULT.withdraw(assets, receiver, owner);
+
+            assets = assets % (maxWithdraw + 1);
+        }
+
+        // SHOULD check `msg.sender` can spend owner funds using allowance
+        shares = VAULT.previewWithdraw(assets);
+        if (owner != msg.sender) {
+            vm.prank(msg.sender);
+            vm.expectRevert();
+            VAULT.withdraw(assets, receiver, owner);
+
+            vm.prank(owner);
+            VAULT.approve(msg.sender, shares);
+        }
+
+        // Collect data
+        uint256 totalAssets = VAULT.totalAssets();
+        uint256 sharesBefore = VAULT.balanceOf(owner);
+        uint256 assetsBefore = VAULT.asset().balanceOf(receiver);
+
+        // Actual action
+        if (assets == 0) {
+            vm.prank(msg.sender);
+            vm.expectRevert(bytes("Aloe: zero impact"));
+            VAULT.withdraw(assets, receiver, owner);
+            shares = 0;
+        } else {
+            vm.prank(msg.sender);
+            vm.expectEmit(true, true, true, true, address(VAULT)); // MUST emit `Withdraw` event
+            emit Withdraw(msg.sender, receiver, owner, assets, shares);
+            require(VAULT.withdraw(shares, receiver, owner) == shares, "withdraw: incorrect preview");
+        }
+
+        // Assertions
+        require(VAULT.totalAssets() == totalAssets - assets, "withdraw: totalAssets mismatch");
+        if (receiver != address(VAULT)) {
+            require(VAULT.asset().balanceOf(receiver) == assetsBefore + assets, "withdraw: transfer issue");
+        } else {
+            require(VAULT.asset().balanceOf(receiver) == assetsBefore, "withdraw: bad self reference");
+        }
+        if (receiver != holders[0]) {
+            require(VAULT.balanceOf(owner) == sharesBefore - shares, "withdraw: burn issue");
+        }
+        // NOTE: We don't make assertions about the change in `totalSupply` because when interest accrues,
+        // shares are minted to reserves (separate from the operations being tested).
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            HELP THE FUZZER
+    //////////////////////////////////////////////////////////////*/
+
+    function redeemStandard(uint256 shares, address receiver) external returns (uint256 assets) {
+        assets = redeem(shares, receiver, msg.sender);
+    }
+
+    function redeemMax(address receiver) external returns (uint256 assets) {
+        assets = redeem(VAULT.maxRedeem(msg.sender), receiver, msg.sender);
+    }
+
+    function withdrawStandard(uint256 assets, address receiver) external returns (uint256 shares) {
+        shares = withdraw(assets, receiver, msg.sender);
+    }
+
+    function withdrawMax(address receiver) external returns (uint256 shares) {
+        shares = withdraw(VAULT.maxWithdraw(msg.sender), receiver, msg.sender);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                             ARRAY LENGTHS
+    //////////////////////////////////////////////////////////////*/
+
+    function getHolderCount() external view returns (uint256) {
+        return holders.length;
+    }
+}

--- a/core/test/invariants/ERC4626Harness.sol
+++ b/core/test/invariants/ERC4626Harness.sol
@@ -42,6 +42,25 @@ contract ERC4626Harness {
                                   MAIN
     //////////////////////////////////////////////////////////////*/
 
+    // I'd prefer for this to be in the invariant testing file, but currently invariants don't accept fuzzed args.
+    // Goal is just to make sure the `convertToXXXXXX` methods (a) don't revert and (b) don't depend on caller.
+    function testViewMethods(address callerA, address callerB, uint128 amount) external {
+        uint256 a;
+        uint256 b;
+
+        vm.prank(callerA);
+        a = VAULT.convertToAssets(amount);
+        vm.prank(callerB);
+        b = VAULT.convertToAssets(amount);
+        require(a == b, "convertToAssets varied with caller");
+
+        vm.prank(callerA);
+        a = VAULT.convertToShares(amount);
+        vm.prank(callerB);
+        b = VAULT.convertToShares(amount);
+        require(a == b, "convertToShares varied with caller");
+    }
+
     /// @dev Don't mess with the logic here, things get weird. See https://github.com/foundry-rs/foundry/issues/3806
     function warp(uint16 elapsedTime) external {
         uint256 t0 = block.timestamp;

--- a/core/test/invariants/ERC4626Invariants.t.sol
+++ b/core/test/invariants/ERC4626Invariants.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.17;
+
+import "forge-std/Test.sol";
+import "forge-std/Vm.sol";
+
+import {ClonesWithImmutableArgs} from "clones-with-immutable-args/ClonesWithImmutableArgs.sol";
+import {ERC4626, ERC20} from "solmate/mixins/ERC4626.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+
+import "src/Lender.sol";
+
+import {ERC4626Harness} from "./ERC4626Harness.sol";
+
+contract ERC4626InvariantsTest is Test {
+    ERC20 public asset;
+
+    ERC4626 public vault;
+
+    ERC4626Harness public vaultHarness;
+
+    struct ThingsThatShouldntChange {
+        string name;
+        string symbol;
+        uint8 decimals;
+        ERC20 asset;
+        bytes32 domainSeparator;
+    }
+
+    ThingsThatShouldntChange public thingsThatShouldntChange;
+
+    function setUp() public {
+        {
+            asset = new MockERC20("Token", "TKN", 18); // TODO: replace 18 with an env var
+            address lenderImplementation = address(new Lender(address(2)));
+            Lender lender = Lender(ClonesWithImmutableArgs.clone(
+                lenderImplementation,
+                abi.encodePacked(address(asset))
+            ));
+            RateModel rateModel = new RateModel();
+            lender.initialize(rateModel, 8); // TODO: replace 8 with an env var
+
+            vault = ERC4626(address(lender));
+            vaultHarness = new ERC4626Harness(lender);
+
+            targetContract(address(vaultHarness));
+
+            // forge can't simulate transactions from addresses with code, so we must exclude all contracts
+            excludeSender(address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D)); // vm
+            excludeSender(address(0x4e59b44847b379578588920cA78FbF26c0B4956C)); // built-in create2 deployer
+            excludeSender(address(this));
+            excludeSender(address(asset));
+            excludeSender(address(lenderImplementation));
+            excludeSender(address(rateModel));
+            excludeSender(address(vault));
+            excludeSender(address(vaultHarness));
+        }
+
+        thingsThatShouldntChange = ThingsThatShouldntChange(
+            vault.name(),
+            vault.symbol(),
+            vault.decimals(),
+            vault.asset(),
+            vault.DOMAIN_SEPARATOR()
+        );
+    }
+
+    function invariant_thingsThatShouldntChangeDontChange() public {
+        ThingsThatShouldntChange memory update = ThingsThatShouldntChange(
+            vault.name(),
+            vault.symbol(),
+            vault.decimals(),
+            vault.asset(),
+            vault.DOMAIN_SEPARATOR()
+        );
+
+        assertEq(bytes(update.name), bytes(thingsThatShouldntChange.name));
+        assertEq(bytes(update.symbol), bytes(thingsThatShouldntChange.symbol));
+        assertEq(update.decimals, thingsThatShouldntChange.decimals);
+        assertEq(address(update.asset), address(thingsThatShouldntChange.asset));
+        assertEq(update.domainSeparator, thingsThatShouldntChange.domainSeparator);
+    }
+
+    function invariant_conversionsAreInverses() public {
+        // Choice of `x` is random/convenient
+        uint256 x = vault.totalSupply();
+
+        // This would need to be true for all `x` in order to fully prove they're inverses
+        assertEq(vault.convertToAssets(vault.convertToShares(x)), x);
+        assertEq(vault.convertToShares(vault.convertToAssets(x)), x);
+    }
+
+    function invariant_totalSupplyEqualsSumOfBalances() public {
+        uint256 totalSupply;
+        uint256 count = vaultHarness.getHolderCount();
+        for (uint256 i = 0; i < count; i++) {
+            totalSupply += vault.balanceOf(vaultHarness.holders(i));
+        }
+        assertEq(totalSupply, vault.totalSupply());
+    }
+
+    function invariant_maxRedeemLessThanBalance() public {
+        uint256 count = vaultHarness.getHolderCount();
+        for (uint256 i = 0; i < count; i++) {
+            address user = vaultHarness.holders(i);
+
+            assertLe(vault.maxRedeem(user), vault.balanceOf(user));
+        }
+    }
+}

--- a/core/test/invariants/LenderHarness.sol
+++ b/core/test/invariants/LenderHarness.sol
@@ -16,6 +16,11 @@ contract FlashBorrower is IFlashBorrower {
     }
 }
 
+// TODO: Add expectEmit
+// TODO: test non-prepaying versions
+// TODO: combine with ERC4626 invariants
+// TODO: Add more assertions (especially surrounding totalSupply) to `accrueInterest`
+
 contract LenderHarness {
     Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
@@ -161,7 +166,7 @@ contract LenderHarness {
         // Make sure `msg.sender` has enough assets to deposit
         if (amountToTransfer > 0) {
             vm.prank(msg.sender);
-            vm.expectRevert(bytes(shares > 0 ? "Aloe: insufficient pre-pay" : "Aloe: zero impact"));
+            vm.expectRevert(bytes(shares > 0 ? "TRANSFER_FROM_FAILED" : "Aloe: zero impact"));
             LENDER.deposit(amount, beneficiary);
 
             MockERC20 mock = MockERC20(address(asset));

--- a/core/test/invariants/LenderInvariants.t.sol
+++ b/core/test/invariants/LenderInvariants.t.sol
@@ -102,7 +102,7 @@ contract LenderInvariantsTest is Test {
         assertEq(bytes(update.name), bytes(thingsThatShouldntChange.name));
         assertEq(bytes(update.symbol), bytes(thingsThatShouldntChange.symbol));
         assertEq(update.decimals, thingsThatShouldntChange.decimals);
-        assertEq(uint160(address(update.asset)), uint160(address(thingsThatShouldntChange.asset)));
+        assertEq(address(update.asset), address(thingsThatShouldntChange.asset));
         assertEq(update.domainSeparator, thingsThatShouldntChange.domainSeparator);
     }
 


### PR DESCRIPTION
Assertions are based on the [official spec](https://eips.ethereum.org/EIPS/eip-4626)

Biggest downside of having these invariants separate from the `Lender` invariants is that they don't get tested with borrows present. I left some TODOs for myself to combine `ERC4626Harness` and `LenderHarness`, so that everything gets tested together.