### PR TITLE
Fix openzeppelin remappings for consumers

### DIFF
--- a/core/foundry.toml
+++ b/core/foundry.toml
@@ -12,9 +12,15 @@ optimizer = true
 optimizer_runs = 4294967295
 gas_reports = []
 
-auto_detect_remappings = true
+auto_detect_remappings = false
 remappings = [
+    'ds-test/=lib/forge-std/lib/ds-test/src/',
+    'forge-std/=lib/forge-std/src/',
+
+    'clones-with-immutable-args/=lib/clones-with-immutable-args/src/',
     'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/',
+    'solmate/=lib/solmate/src/',
+    'v3-core/=lib/v3-core/'
 ]
 
 [fuzz]

--- a/core/foundry.toml
+++ b/core/foundry.toml
@@ -18,7 +18,7 @@ remappings = [
     'forge-std/=lib/forge-std/src/',
 
     'clones-with-immutable-args/=lib/clones-with-immutable-args/src/',
-    'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/',
+    'openzeppelin-contracts/=lib/openzeppelin-contracts/',
     'solmate/=lib/solmate/src/',
     'v3-core/=lib/v3-core/'
 ]

--- a/core/src/Borrower.sol
+++ b/core/src/Borrower.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.17;
 
-import {Math} from "openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {ERC20, SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
 
 import {IUniswapV3MintCallback} from "v3-core/contracts/interfaces/callback/IUniswapV3MintCallback.sol";

--- a/core/src/Ledger.sol
+++ b/core/src/Ledger.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.17;
 
 import {ImmutableArgs} from "clones-with-immutable-args/ImmutableArgs.sol";
-import {IERC165} from "openzeppelin-contracts/interfaces/IERC165.sol";
-import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
-import {Math} from "openzeppelin-contracts/utils/math/Math.sol";
+import {IERC165} from "openzeppelin-contracts/contracts/interfaces/IERC165.sol";
+import {IERC4626} from "openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {ERC20} from "solmate/tokens/ERC20.sol";
 

--- a/core/src/libraries/BalanceSheet.sol
+++ b/core/src/libraries/BalanceSheet.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.17;
 
-import {Math} from "openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {SafeCastLib} from "solmate/utils/SafeCastLib.sol";
 

--- a/core/src/libraries/LiquidityAmounts.sol
+++ b/core/src/libraries/LiquidityAmounts.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.17;
 
-import {Math} from "openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {SafeCastLib} from "solmate/utils/SafeCastLib.sol";
 
 import {Q96} from "./constants/Q.sol";

--- a/core/src/libraries/Volatility.sol
+++ b/core/src/libraries/Volatility.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.17;
 
-import {Math} from "openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 
 import {Q96} from "./constants/Q.sol";

--- a/core/test/libraries/Log2.t.sol
+++ b/core/test/libraries/Log2.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import "forge-std/Test.sol";
 
-import {Math} from "openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 
 import "src/libraries/Log2.sol";
 

--- a/core/test/libraries/Volatility.t.sol
+++ b/core/test/libraries/Volatility.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import "forge-std/Test.sol";
 
-import {Math} from "openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 
 import {TickMath} from "src/libraries/TickMath.sol";
 import {Volatility} from "src/libraries/Volatility.sol";

--- a/periphery/deploy.sh
+++ b/periphery/deploy.sh
@@ -8,7 +8,7 @@ cp -R ../core/lib lib/core/lib
 cp ../core/foundry.toml lib/core/
 
 source .env
-forge clean
+# forge clean
 forge build
 forge script script/Deploy.s.sol:DeployScript --broadcast --verify
 

--- a/periphery/foundry.toml
+++ b/periphery/foundry.toml
@@ -18,7 +18,7 @@ remappings = [
     'forge-std/=lib/core/lib/forge-std/src/',
 
     'clones-with-immutable-args/=lib/core/lib/clones-with-immutable-args/src',
-    'openzeppelin-contracts/=lib/core/lib/openzeppelin-contracts/contracts/',
+    'openzeppelin-contracts/=lib/core/lib/openzeppelin-contracts/',
     'solmate/=lib/core/lib/solmate/src/',
     'v3-core/=lib/core/lib/v3-core/',
 

--- a/periphery/foundry.toml
+++ b/periphery/foundry.toml
@@ -12,9 +12,10 @@ optimizer = true
 optimizer_runs = 800
 gas_reports = []
 
-auto_detect_remappings = true
+auto_detect_remappings = false
 remappings = [
-    'forge-std/=lib/core/lib/forge-std/src',
+    'ds-test/=lib/core/lib/forge-std/lib/ds-test/src/',
+    'forge-std/=lib/core/lib/forge-std/src/',
 
     'clones-with-immutable-args/=lib/core/lib/clones-with-immutable-args/src',
     'openzeppelin-contracts/=lib/core/lib/openzeppelin-contracts/contracts/',

--- a/periphery/src/LenderLens.sol
+++ b/periphery/src/LenderLens.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.17;
 
-import {Math} from "openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {ERC20} from "solmate/tokens/ERC20.sol";
 
 import {Lender} from "aloe-ii-core/Lender.sol";

--- a/periphery/src/interfaces/IERC721Permit.sol
+++ b/periphery/src/interfaces/IERC721Permit.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.17;
 
-import {IERC721} from "openzeppelin-contracts/token/ERC721/IERC721.sol";
+import {IERC721} from "openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
 
 /* solhint-disable */
 

--- a/periphery/src/interfaces/INonfungiblePositionManager.sol
+++ b/periphery/src/interfaces/INonfungiblePositionManager.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/token/ERC721/extensions/IERC721Metadata.sol";
-import "openzeppelin-contracts/token/ERC721/extensions/IERC721Enumerable.sol";
+import "openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import "openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
 
 import {IERC721Permit} from "./IERC721Permit.sol";
 

--- a/periphery/src/libraries/Uniswap.sol
+++ b/periphery/src/libraries/Uniswap.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.17;
 
-import {Math} from "openzeppelin-contracts/utils/math/Math.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {IUniswapV3Pool} from "v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 
 import {Q128} from "aloe-ii-core/libraries/constants/Q.sol";

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,7 +1,2 @@
-clones-with-immutable-args/=core/lib/clones-with-immutable-args/src/
-openzeppelin-contracts/=core/lib/openzeppelin-contracts/contracts/
-solmate/=core/lib/solmate/src/
-v3-core/=core/lib/v3-core/
-
 aloe-ii-core/=core/src/
 aloe-ii-periphery/=periphery/src/


### PR DESCRIPTION
Trying to install aloe-ii in a new repository for Fuse wrappers. Ran into an issue where I would've had to manually define openzeppelin remappings. This fixes it so it works out-of-the-box.