### PR TITLE
Fix divide before multiply in BalanceSheet

### DIFF
--- a/core/src/libraries/BalanceSheet.sol
+++ b/core/src/libraries/BalanceSheet.sol
@@ -107,7 +107,7 @@ library BalanceSheet {
                 uint256 shortfall = liabilities0 - assets0;
                 // to cover it, a liquidator may have to use their own assets, taking on inventory risk.
                 // to compensate them for this risk, they're allowed to seize some of the surplus asset.
-                incentive1 += mulDiv96(shortfall / LIQUIDATION_INCENTIVE, meanPriceX96);
+                incentive1 += mulDiv96(shortfall, meanPriceX96) / LIQUIDATION_INCENTIVE;
             }
 
             if (liabilities1 > assets1) {


### PR DESCRIPTION
Reverting change described [here](https://github.com/aloelabs/aloe-ii/pull/30#discussion_r1073239600) as precision is more of a worry than overflow.