### PR TITLE
Add comment regarding oracle cardinality upkeep

### DIFF
--- a/core/src/libraries/Volatility.sol
+++ b/core/src/libraries/Volatility.sol
@@ -14,8 +14,6 @@ import {TickMath} from "./TickMath.sol";
 /// @author Aloe Labs, Inc.
 library Volatility {
     struct PoolMetadata {
-        // the oldest oracle observation that's been populated by the pool
-        uint32 maxSecondsAgo;
         // the overall fee minus the protocol fee for token0, times 1e6
         uint24 gamma0;
         // the overall fee minus the protocol fee for token1, times 1e6

--- a/core/test/VolatilityOracle.t.sol
+++ b/core/test/VolatilityOracle.t.sol
@@ -65,7 +65,7 @@ contract VolatilityOracleTest is Test {
 
             oracle.prepare(pool);
 
-            (, uint256 gamma0, uint256 gamma1, ) = oracle.cachedMetadata(pool);
+            (uint256 gamma0, uint256 gamma1, ) = oracle.cachedMetadata(pool);
             (uint256 fgg0, uint256 fgg1, uint256 fggTime) = oracle.feeGrowthGlobals(pool, 0);
             (uint256 index, uint256 time, uint256 iv) = oracle.lastWrites(pool);
 

--- a/core/test/libraries/Volatility.t.sol
+++ b/core/test/libraries/Volatility.t.sol
@@ -11,7 +11,7 @@ contract VolatilityTest is Test {
     function setUp() public {}
 
     function test_spec_estimate() public {
-        Volatility.PoolMetadata memory metadata = Volatility.PoolMetadata(3600, 3000, 3000, 60);
+        Volatility.PoolMetadata memory metadata = Volatility.PoolMetadata(3000, 3000, 60);
         Oracle.PoolData memory data = Oracle.PoolData(
             1278673744380353403099539498152303, // sqrtPriceX96
             193789, // currentTick
@@ -111,7 +111,7 @@ contract VolatilityTest is Test {
         uint48 c,
         uint48 d
     ) public pure {
-        Volatility.PoolMetadata memory metadata = Volatility.PoolMetadata(3600, 3000, 3000, 60);
+        Volatility.PoolMetadata memory metadata = Volatility.PoolMetadata(3000, 3000, 60);
         Oracle.PoolData memory data = Oracle.PoolData(
             TickMath.getSqrtRatioAtTick(tick), // sqrtPriceX96
             tick, // currentTick
@@ -280,7 +280,6 @@ contract VolatilityTest is Test {
         oracleLookback = uint32(bound(oracleLookback, 15 seconds, 1 days));
 
         Volatility.PoolMetadata memory metadata = Volatility.PoolMetadata(
-            0,
             uint24(gammas % (1 << 24)),
             uint24(gammas >> 24),
             0


### PR DESCRIPTION
When we started reading observation from 1 hour ago (in addition to 30 minutes ago) I forgot to update the initial cardinality check. Fixed that, and increased the safety factor from 2x to 3x.

Also removed `maxSecondsAgo` from the metadata struct, since we didn't use it anywhere.