### PR TITLE
Stronger manipulation protection in VolatilityOracle

### DIFF
--- a/core/src/libraries/constants/Constants.sol
+++ b/core/src/libraries/constants/Constants.sol
@@ -118,6 +118,11 @@ uint128 constant IV_COLD_START = uint128((PROBE_PERCENT_MAX * 10) / CONSTRAINT_N
 /// change by 0.0000463 percentage points per second → 4 percentage points per day.
 uint256 constant IV_CHANGE_PER_SECOND = 462962;
 
+/// @dev The maximum amount by which (reported) implied volatility can change with a single `VolatilityOracle.update`
+/// call. If updates happen as frequently as possible (every `FEE_GROWTH_SAMPLE_PERIOD`), this cap is no different
+/// from `IV_CHANGE_PER_SECOND` alone.
+uint256 constant IV_CHANGE_PER_UPDATE = IV_CHANGE_PER_SECOND * FEE_GROWTH_SAMPLE_PERIOD;
+
 /// @dev To estimate volume, we need 2 samples. One is always at the current block, the other is from
 /// `FEE_GROWTH_AVG_WINDOW` seconds ago, +/- `FEE_GROWTH_SAMPLE_PERIOD / 2`. Larger values make the resulting volume
 /// estimate more robust, but may cause the oracle to miss brief spikes in activity.
@@ -126,11 +131,11 @@ uint256 constant FEE_GROWTH_AVG_WINDOW = 6 hours;
 /// @dev The length of the circular buffer that stores feeGrowthGlobals samples.
 /// Must be in interval
 /// \\( \left[ \frac{\text{FEE_GROWTH_AVG_WINDOW}}{\text{FEE_GROWTH_SAMPLE_PERIOD}}, 256 \right) \\)
-uint256 constant FEE_GROWTH_ARRAY_LENGTH = 48;
+uint256 constant FEE_GROWTH_ARRAY_LENGTH = 32;
 
 /// @dev The minimum number of seconds that must elapse before a new feeGrowthGlobals sample will be stored. This
 /// controls how often the oracle can update IV.
-uint256 constant FEE_GROWTH_SAMPLE_PERIOD = 15 minutes;
+uint256 constant FEE_GROWTH_SAMPLE_PERIOD = 1 hours;
 
 /// @dev To compute Uniswap mean price & liquidity, we need 2 samples. One is always at the current block, the other is
 /// from `UNISWAP_AVG_WINDOW` seconds ago. Larger values make the resulting price/liquidity values harder to

--- a/core/test/VolatilityOracle.t.sol
+++ b/core/test/VolatilityOracle.t.sol
@@ -183,7 +183,7 @@ contract VolatilityOracleTest is Test {
             assertEqDecimal(ivStored, ivWritten, 12);
             assertEq(newIndex, (currentIndex + 1) % FEE_GROWTH_ARRAY_LENGTH);
 
-            uint256 maxChange = (newTime - currentTime) * IV_CHANGE_PER_SECOND;
+            uint256 maxChange = IV_CHANGE_PER_UPDATE;
             assertLe(ivWritten, currentIV + maxChange);
             assertGe(ivWritten + maxChange, currentIV);
 


### PR DESCRIPTION
Talking about manipulation of IV, not price (although they may go hand in hand).

Already had constraint on `IV_CHANGE_PER_SECOND` which guarantees no more than a 4% move per day. At our default `nSigma` of 5, this corresponds to a 20% change in probe prices. Large but manageable especially with our notification service (wip).

However, due to implementation details, I realized you could achieve that 4% move with just 4 updates (24 hour day / 6 hour update window). So someone who wants to mess with IV would only need to target those 4 updates, and increase/decrease liquidity at the current tick.

I changed it so that instead of the maximum update size being _de facto_ `IV_CHANGE_PER_SECOND * FEE_GROWTH_AVG_WINDOW` (approximately anyway), it's now explicitly set to `IV_CHANGE_PER_SECOND * FEE_GROWTH_SAMPLE_PERIOD`. This retains the 4%-move-per-day property, but instead of needing to hit the minimum number of updates (4) you now need to hit all of them (24 hour day / 1 hour sample period = 24).

TLDR; A single IV update is constrained to 0.16% instead of 1% (0.83% vs 5% in probe-prices-land). This gives borrowers time to react and reduces the incentive to manipulate IV via `pool.liquidity()`.