### PR TITLE
Move extract to Positions library for clearer syntax in Borrower

### DIFF
--- a/core/src/Borrower.sol
+++ b/core/src/Borrower.sol
@@ -12,7 +12,7 @@ import {Q128} from "./libraries/constants/Q.sol";
 import {BalanceSheet, Assets, Prices} from "./libraries/BalanceSheet.sol";
 import {LiquidityAmounts} from "./libraries/LiquidityAmounts.sol";
 import {square, mulDiv128} from "./libraries/MulDiv.sol";
-import {extract} from "./libraries/Positions.sol";
+import {Positions} from "./libraries/Positions.sol";
 import {TickMath} from "./libraries/TickMath.sol";
 
 import {Factory} from "./Factory.sol";
@@ -445,7 +445,7 @@ contract Borrower is IUniswapV3MintCallback {
     //////////////////////////////////////////////////////////////*/
 
     function getUniswapPositions() external view returns (int24[] memory) {
-        return extract(_loadSlot0());
+        return Positions.extract(_loadSlot0());
     }
 
     function getPrices(uint40 oracleSeed) public view returns (Prices memory prices, bool seemsLegit) {
@@ -476,7 +476,7 @@ contract Borrower is IUniswapV3MintCallback {
         assets.fixed0 = TOKEN0.balanceOf(address(this));
         assets.fixed1 = TOKEN1.balanceOf(address(this));
 
-        int24[] memory positions = extract(slot0_);
+        int24[] memory positions = Positions.extract(slot0_);
         uint256 count = positions.length;
         unchecked {
             for (uint256 i; i < count; i += 2) {

--- a/core/src/libraries/Positions.sol
+++ b/core/src/libraries/Positions.sol
@@ -19,79 +19,77 @@ function zip(int24[6] memory positions) pure returns (uint144 zipped) {
     }
 }
 
-/**
- * @notice Extracts up to three Uniswap positions from `zipped`. Each position consists of an `int24 lower` and
- * `int24 upper`, and will be included in the output array *iff* `lower != upper`. The output array is flattened
- * such that lower and upper ticks are next to each other, e.g. one position may be at indices 0 & 1, and another
- * at indices 2 & 3.
- * @dev The output array's length will be one of {0, 2, 4, 6}. We do *not* validate that `lower < upper`, nor do
- * we check whether positions actually hold liquidity. Also note that this function will revert if `zipped`
- * contains duplicate positions like [-100, 100, -100, 100].
- * @param zipped Encoded Uniswap positions. Equivalent to the layout of `int24[6] storage yourPositions`
- * @return positionsOfNonZeroWidth Flattened array of Uniswap positions that may or may not hold liquidity
- */
-function extract(uint256 zipped) pure returns (int24[] memory positionsOfNonZeroWidth) {
-    assembly ("memory-safe") {
-        // zipped:
-        // -->  xl + (xu << 24) + (yl << 48) + (yu << 72) + (zl << 96) + (zu << 120)
-        // -->  |-------|-----|----|----|----|----|----|
-        //      | shift | 120 | 96 | 72 | 48 | 24 |  0 |
-        //      | value |  zu | zl | yu | yl | xu | xl |
-        //      |-------|-----|----|----|----|----|----|
-
-        positionsOfNonZeroWidth := mload(0x40)
-        let offset := 32
-
-        // if xl != xu
-        let l := mod(zipped, Q24)
-        let u := mod(shr(24, zipped), Q24)
-        if iszero(eq(l, u)) {
-            mstore(add(positionsOfNonZeroWidth, 32), l)
-            mstore(add(positionsOfNonZeroWidth, 64), u)
-            offset := 96
-        }
-
-        // if yl != yu
-        l := mod(shr(48, zipped), Q24)
-        u := mod(shr(72, zipped), Q24)
-        if iszero(eq(l, u)) {
-            let isSameAsX := eq(mod(shr(48, zipped), Q48), mod(zipped, Q48))
-            if isSameAsX {
-                // revert with `DuplicatePosition()`
-                mstore(0x00, 0xe13355df)
-                revert(0x1c, 0x04)
-            }
-
-            mstore(add(positionsOfNonZeroWidth, offset), l)
-            mstore(add(positionsOfNonZeroWidth, add(offset, 32)), u)
-            offset := add(offset, 64)
-        }
-
-        // if zl != zu
-        l := mod(shr(96, zipped), Q24)
-        u := mod(shr(120, zipped), Q24)
-        if iszero(eq(l, u)) {
-            let isSameAsX := eq(mod(shr(96, zipped), Q48), mod(zipped, Q48))
-            let isSameAsY := eq(mod(shr(96, zipped), Q48), mod(shr(48, zipped), Q48))
-            if or(isSameAsX, isSameAsY) {
-                // revert with `DuplicatePosition()`
-                mstore(0x00, 0xe13355df)
-                revert(0x1c, 0x04)
-            }
-
-            mstore(add(positionsOfNonZeroWidth, offset), l)
-            mstore(add(positionsOfNonZeroWidth, add(offset, 32)), u)
-            offset := add(offset, 64)
-        }
-
-        mstore(positionsOfNonZeroWidth, shr(5, sub(offset, 32)))
-        mstore(0x40, add(positionsOfNonZeroWidth, offset))
-    }
-}
-
 /// @title Positions
 /// @notice Provides functions for handling Uniswap positions in `Borrower`'s storage
 /// @author Aloe Labs, Inc.
 library Positions {
+    /**
+     * @notice Extracts up to three Uniswap positions from `zipped`. Each position consists of an `int24 lower` and
+     * `int24 upper`, and will be included in the output array *iff* `lower != upper`. The output array is flattened
+     * such that lower and upper ticks are next to each other, e.g. one position may be at indices 0 & 1, and another
+     * at indices 2 & 3.
+     * @dev The output array's length will be one of {0, 2, 4, 6}. We do *not* validate that `lower < upper`, nor do
+     * we check whether positions actually hold liquidity. Also note that this function will revert if `zipped`
+     * contains duplicate positions like [-100, 100, -100, 100].
+     * @param zipped Encoded Uniswap positions. Equivalent to the layout of `int24[6] storage yourPositions`
+     * @return positionsOfNonZeroWidth Flattened array of Uniswap positions that may or may not hold liquidity
+     */
+    function extract(uint256 zipped) internal pure returns (int24[] memory positionsOfNonZeroWidth) {
+        assembly ("memory-safe") {
+            // zipped:
+            // -->  xl + (xu << 24) + (yl << 48) + (yu << 72) + (zl << 96) + (zu << 120)
+            // -->  |-------|-----|----|----|----|----|----|
+            //      | shift | 120 | 96 | 72 | 48 | 24 |  0 |
+            //      | value |  zu | zl | yu | yl | xu | xl |
+            //      |-------|-----|----|----|----|----|----|
 
+            positionsOfNonZeroWidth := mload(0x40)
+            let offset := 32
+
+            // if xl != xu
+            let l := mod(zipped, Q24)
+            let u := mod(shr(24, zipped), Q24)
+            if iszero(eq(l, u)) {
+                mstore(add(positionsOfNonZeroWidth, 32), l)
+                mstore(add(positionsOfNonZeroWidth, 64), u)
+                offset := 96
+            }
+
+            // if yl != yu
+            l := mod(shr(48, zipped), Q24)
+            u := mod(shr(72, zipped), Q24)
+            if iszero(eq(l, u)) {
+                let isSameAsX := eq(mod(shr(48, zipped), Q48), mod(zipped, Q48))
+                if isSameAsX {
+                    // revert with `DuplicatePosition()`
+                    mstore(0x00, 0xe13355df)
+                    revert(0x1c, 0x04)
+                }
+
+                mstore(add(positionsOfNonZeroWidth, offset), l)
+                mstore(add(positionsOfNonZeroWidth, add(offset, 32)), u)
+                offset := add(offset, 64)
+            }
+
+            // if zl != zu
+            l := mod(shr(96, zipped), Q24)
+            u := mod(shr(120, zipped), Q24)
+            if iszero(eq(l, u)) {
+                let isSameAsX := eq(mod(shr(96, zipped), Q48), mod(zipped, Q48))
+                let isSameAsY := eq(mod(shr(96, zipped), Q48), mod(shr(48, zipped), Q48))
+                if or(isSameAsX, isSameAsY) {
+                    // revert with `DuplicatePosition()`
+                    mstore(0x00, 0xe13355df)
+                    revert(0x1c, 0x04)
+                }
+
+                mstore(add(positionsOfNonZeroWidth, offset), l)
+                mstore(add(positionsOfNonZeroWidth, add(offset, 32)), u)
+                offset := add(offset, 64)
+            }
+
+            mstore(positionsOfNonZeroWidth, shr(5, sub(offset, 32)))
+            mstore(0x40, add(positionsOfNonZeroWidth, offset))
+        }
+    }
 }

--- a/core/test/libraries/Positions.t.sol
+++ b/core/test/libraries/Positions.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import "forge-std/Test.sol";
 
-import {Positions, extract, zip} from "src/libraries/Positions.sol";
+import {Positions, zip} from "src/libraries/Positions.sol";
 
 contract PositionsTest is Test {
     using Positions for int24[6];
@@ -42,7 +42,7 @@ contract PositionsTest is Test {
         }
 
         vm.expectSafeMemory(ptr, ptr + 32 * (1 + 2 * count));
-        extract(zipped);
+        Positions.extract(zipped);
     }
 
     function test_memoryExtractDirtyZip(
@@ -59,7 +59,7 @@ contract PositionsTest is Test {
         vm.assume(zl != xl || zu != xu);
 
         uint256 zipped = zip([xl, xu, yl, yu, zl, zu]) + (uint256(dirt) << 144);
-        int24[] memory extracted = extract(zipped);
+        int24[] memory extracted = Positions.extract(zipped);
 
         if (xl == xu && yl == yu && zl == zu) {
             assertEq(extracted.length, 0);
@@ -138,7 +138,7 @@ contract PositionsTest is Test {
             // ...could add more, doesn't really matter
         }
 
-        int24[] memory extracted = extract(zipped);
+        int24[] memory extracted = Positions.extract(zipped);
         if (xl != xu) {
             assertEq(extracted.length, 2);
             assertEq(extracted[0], xl);
@@ -441,7 +441,7 @@ contract PositionsTest is Test {
 
             sstore(positions.slot, slot0)
         }
-        positions_ = extract(slot0);
+        positions_ = Positions.extract(slot0);
     }
 
     function _read() private view returns (int24[] memory positions_) {
@@ -449,6 +449,6 @@ contract PositionsTest is Test {
         assembly ("memory-safe") {
             slot0 := sload(positions.slot)
         }
-        positions_ = extract(slot0);
+        positions_ = Positions.extract(slot0);
     }
 }


### PR DESCRIPTION
Previously `extract` was a free file-level function, now it's inside the `Positions` library