### PR TITLE
Add courier enrollment fee to mitigate griefing vector

### DIFF
--- a/core/script/Deploy.s.sol
+++ b/core/script/Deploy.s.sol
@@ -9,7 +9,7 @@ import {RateModel} from "src/RateModel.sol";
 import {VolatilityOracle} from "src/VolatilityOracle.sol";
 
 address constant GOVERNOR = 0x2bf8eA41aF0695D482C4aa23d4f8aD7E9023b890;
-address constant RESERVE = 0xAd236E154cbC33cFDB6CD7A4BA04679d9fb74A8C;
+address payable constant RESERVE = payable(0xAd236E154cbC33cFDB6CD7A4BA04679d9fb74A8C);
 
 // Derived using https://github.com/0age/create2crunch/
 bytes32 constant saltA = 0x0000000000000000000000000000000000000000aeeec55d74c86000021e5622;

--- a/core/src/libraries/constants/Constants.sol
+++ b/core/src/libraries/constants/Constants.sol
@@ -23,6 +23,10 @@ uint256 constant BORROWS_SCALER = ONE << 72;
 /// > - MAX_RATE: (exp(maxAPR / secondsPerYear) - 1) * 1e12
 uint256 constant MAX_RATE = 706354;
 
+/// @dev The amount of ETH prospective couriers must pay in order to enroll and claim a `courierId`. Designed to
+/// prevent griefing, since there are only (2^32 - 1) `courierId`s available.
+uint256 constant COURIER_ENROLLMENT_FEE = 0.01 ether;
+
 /*//////////////////////////////////////////////////////////////
                         FACTORY DEFAULTS
 //////////////////////////////////////////////////////////////*/

--- a/core/test/Borrower.t.sol
+++ b/core/test/Borrower.t.sol
@@ -52,7 +52,7 @@ contract BorrowerTest is Test, IManager, IUniswapV3SwapCallback {
 
         VolatilityOracle oracle = new VolatilityOracle();
         RateModel rateModel = new RateModel();
-        factory = new FatFactory(address(0), address(0), oracle, rateModel);
+        factory = new FatFactory(address(0), payable(0), oracle, rateModel);
 
         factory.createMarket(pool);
         (lender0, lender1, impl) = factory.getMarket(pool);

--- a/core/test/LenderReferrals.t.sol
+++ b/core/test/LenderReferrals.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 
+import {COURIER_ENROLLMENT_FEE} from "src/libraries/constants/Constants.sol";
 import "src/Lender.sol";
 import "src/RateModel.sol";
 
@@ -36,9 +37,9 @@ contract LenderReferralsTest is Test {
         vm.assume(id != 0);
 
         Factory factory = lender.FACTORY();
-        vm.prank(wallet);
+        hoax(wallet, 1 ether);
         vm.expectRevert(bytes(""));
-        factory.enrollCourier(id, 0);
+        factory.enrollCourier{value: COURIER_ENROLLMENT_FEE}(id, 0);
     }
 
     function test_cannotSetCutAbove10000(uint32 id, address wallet, uint16 cut) public {
@@ -46,18 +47,18 @@ contract LenderReferralsTest is Test {
         if (cut < 10_000) cut += 10_000;
 
         Factory factory = lender.FACTORY();
-        vm.prank(wallet);
+        hoax(wallet, 1 ether);
         vm.expectRevert(bytes(""));
-        factory.enrollCourier(id, cut);
+        factory.enrollCourier{value: COURIER_ENROLLMENT_FEE}(id, cut);
     }
 
     function test_cannotEnrollId0(address wallet, uint16 cut) public {
         vm.assume(cut != 0);
 
         Factory factory = lender.FACTORY();
-        vm.prank(wallet);
+        hoax(wallet, 1 ether);
         vm.expectRevert(bytes(""));
-        factory.enrollCourier(0, cut);
+        factory.enrollCourier{value: COURIER_ENROLLMENT_FEE}(0, cut);
     }
 
     function test_cannotEditCourierCut(uint32 id, address wallet, uint16 cutA, uint16 cutB) public {
@@ -70,11 +71,11 @@ contract LenderReferralsTest is Test {
 
         Factory factory = lender.FACTORY();
 
-        vm.prank(wallet);
-        factory.enrollCourier(id, cutA);
-        vm.prank(wallet);
+        hoax(wallet, 1 ether);
+        factory.enrollCourier{value: COURIER_ENROLLMENT_FEE}(id, cutA);
+        hoax(wallet, 1 ether);
         vm.expectRevert(bytes(""));
-        factory.enrollCourier(id, cutB);
+        factory.enrollCourier{value: COURIER_ENROLLMENT_FEE}(id, cutB);
     }
 
     function test_cannotEditCourierWallet(uint32 id, address walletA, address walletB, uint16 cut) public {
@@ -84,11 +85,11 @@ contract LenderReferralsTest is Test {
 
         Factory factory = lender.FACTORY();
 
-        vm.prank(walletA);
-        factory.enrollCourier(id, cut);
-        vm.prank(walletB);
+        hoax(walletA, 1 ether);
+        factory.enrollCourier{value: COURIER_ENROLLMENT_FEE}(id, cut);
+        hoax(walletB, 1 ether);
         vm.expectRevert(bytes(""));
-        factory.enrollCourier(id, cut);
+        factory.enrollCourier{value: COURIER_ENROLLMENT_FEE}(id, cut);
     }
 
     function test_canCreditCourier(uint32 id, address wallet, uint16 cut) public {
@@ -284,8 +285,8 @@ contract LenderReferralsTest is Test {
         vm.assume(cut != 0);
 
         Factory factory = lender.FACTORY();
-        vm.prank(wallet);
-        factory.enrollCourier(id, cut);
+        hoax(wallet, 1 ether);
+        factory.enrollCourier{value: COURIER_ENROLLMENT_FEE}(id, cut);
 
         return (id, wallet, cut);
     }

--- a/core/test/Liquidator.t.sol
+++ b/core/test/Liquidator.t.sol
@@ -29,7 +29,7 @@ contract LiquidatorTest is Test, IManager, ILiquidator {
 
         Factory factory = new FatFactory(
             address(0),
-            address(0),
+            payable(0),
             VolatilityOracle(address(new VolatilityOracleMock())),
             new RateModel()
         );

--- a/core/test/Utils.sol
+++ b/core/test/Utils.sol
@@ -17,17 +17,19 @@ import {VolatilityOracle} from "src/VolatilityOracle.sol";
 contract FatFactory is Factory {
     constructor(
         address governor,
-        address reserve,
+        address payable reserve,
         VolatilityOracle oracle,
         IRateModel defaultRateModel
     ) Factory(governor, reserve, oracle, new BorrowerDeployer(), defaultRateModel) {}
 }
 
 contract FactoryForLenderTests is FatFactory {
+    receive() external payable {}
+
     constructor(
         RateModel rateModel,
         ERC20 rewardsToken_
-    ) FatFactory(address(0), address(this), VolatilityOracle(address(0)), rateModel) {
+    ) FatFactory(address(0), payable(this), VolatilityOracle(address(0)), rateModel) {
         rewardsToken = rewardsToken_;
     }
 

--- a/core/test/gas/BorrowerGas.t.sol
+++ b/core/test/gas/BorrowerGas.t.sol
@@ -29,7 +29,7 @@ contract BorrowerGasTest is Test, IManager {
 
         Factory factory = new FatFactory(
             address(0),
-            address(0),
+            payable(0),
             VolatilityOracle(address(new VolatilityOracleMock())),
             new RateModel()
         );

--- a/core/test/gas/FactoryGas.t.sol
+++ b/core/test/gas/FactoryGas.t.sol
@@ -21,7 +21,7 @@ contract FactoryGasTest is Test {
 
         factory = new FatFactory(
             address(0),
-            address(0),
+            payable(0),
             new VolatilityOracle(),
             new RateModel()
         );

--- a/core/test/gas/LenderGas.t.sol
+++ b/core/test/gas/LenderGas.t.sol
@@ -65,8 +65,8 @@ contract LenderGasTest is Test {
 
         // Setup courier#1
         Factory factory = lender.FACTORY();
-        vm.prank(address(12345));
-        factory.enrollCourier(1, 1000);
+        hoax(address(12345), 1 ether);
+        factory.enrollCourier{value: COURIER_ENROLLMENT_FEE}(1, 1000);
 
         // `alice` deposits 0.5 WETH, crediting courier#1
         asset.transferFrom(alice, address(lender), 0.5e18);

--- a/core/test/gas/LiquidatorGas.t.sol
+++ b/core/test/gas/LiquidatorGas.t.sol
@@ -29,7 +29,7 @@ contract LiquidatorGasTest is Test, IManager, ILiquidator {
 
         Factory factory = new FatFactory(
             address(0),
-            address(0),
+            payable(0),
             VolatilityOracle(address(new VolatilityOracleMock())),
             new RateModel()
         );


### PR DESCRIPTION
Require prospective couriers to pay 0.01 ETH in order to enroll. Filling all 2^32 - 1 `courierId`s would now cost nearly 43 million ETH, regardless of gas costs. Front-running individual enrollment transactions is also an order of magnitude more expensive, but if it's still a problem, users could enroll via a private mempool.

Addresses
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/1
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/26
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/56
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/140