### PR TITLE
accrueInterest() before setting new rateModel

### DIFF
--- a/core/src/Lender.sol
+++ b/core/src/Lender.sol
@@ -58,6 +58,8 @@ contract Lender is Ledger {
 
     /// @notice Sets the `rateModel` and `reserveFactor`. Only the `FACTORY` can call this.
     function setRateModelAndReserveFactor(IRateModel rateModel_, uint8 reserveFactor_) external {
+        this.accrueInterest();
+
         require(msg.sender == address(FACTORY) && reserveFactor_ > 0);
         rateModel = rateModel_;
         reserveFactor = reserveFactor_;
@@ -540,7 +542,7 @@ contract Lender is Ledger {
         uint256 newTotalSupply;
         (cache, inventory, newTotalSupply) = _previewInterest(cache); // Reverts if reentrancy guard is active
 
-        // Update reserves (new `totalSupply` is only in memory, but `balanceOf` is updated in storage)
+        // Update reserves (new `totalSupply` is only in memory, but `balances[RESERVE]` is updated in storage)
         if (newTotalSupply > cache.totalSupply) {
             cache.totalSupply = _mint(RESERVE, newTotalSupply - cache.totalSupply, 0, cache.totalSupply, 0);
         }

--- a/core/test/Lender.t.sol
+++ b/core/test/Lender.t.sol
@@ -81,10 +81,10 @@ contract LenderTest is Test {
             prevIndex = currIndex;
         }
 
-        // 52 weeks per year, so at 53 weeks we expect failure
+        // 52 weeks per year, so at 53 weeks we expect it to hit max uint72
         vm.warp(1 weeks * 53);
-        vm.expectRevert();
         lender.accrueInterest();
+        assertEq(lender.borrowIndex(), type(uint72).max);
     }
 
     function test_accrueInterest(uint256 yieldPerSecond) public {


### PR DESCRIPTION
The latest interest should be accrued using the old `rateModel` before updating to the new one.

One other thing -- previously, if accrued interest was causing the safe casts in `_save` to revert, governance could un-brick the contract by setting a new `rateModel` that returns 0. After this change, that wouldn't be possible, because `setRateModelAndReserveFactor` itself would revert. We eliminate the problem by clamping `borrowIndex` and `totalSupply` to their maximum values in `_previewInterest`.

Addresses
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/122