### PR TITLE
Increase LIQUIDATION_GRACE_PERIOD to 5 minutes

### DIFF
--- a/core/src/Borrower.sol
+++ b/core/src/Borrower.sol
@@ -50,7 +50,7 @@ contract Borrower is IUniswapV3MintCallback {
     /**
      * @notice Most liquidations involve swapping one asset for another. To incentivize such swaps (even in
      * volatile markets) liquidators are rewarded with a 5% bonus. To avoid paying that bonus to liquidators,
-     * the account owner can listen for this event. Once it's emitted, they have 2 minutes to bring the
+     * the account owner can listen for this event. Once it's emitted, they have 5 minutes to bring the
      * account back to health. If they fail, the liquidation will proceed.
      * @dev Fortuitous price movements and/or direct `Lender.repay` can bring the account back to health and
      * nullify the immediate liquidation threat, but they will not clear the warning. This means that next

--- a/core/src/libraries/constants/Constants.sol
+++ b/core/src/libraries/constants/Constants.sol
@@ -89,7 +89,7 @@ uint256 constant LIQUIDATION_INCENTIVE = 20;
 
 /// @dev The minimum time that must pass between `Borrower.warn` and `Borrower.liquidate` for any liquidation that
 /// involves the swap callbacks (`swap1For0` and `swap0For1`). There is no grace period for in-kind liquidations.
-uint256 constant LIQUIDATION_GRACE_PERIOD = 2 minutes;
+uint256 constant LIQUIDATION_GRACE_PERIOD = 5 minutes;
 
 /// @dev The minimum scaling factor by which `sqrtMeanPriceX96` is multiplied or divided to get probe prices
 uint256 constant PROBE_SQRT_SCALER_MIN = 1.026248453011e12;


### PR DESCRIPTION
While we do want the `Warn` event to give borrowers time to save themselves from liquidation, its _primary_ purpose is to prevent manipulation of liquidation rewards (i.e., prevent liquidators from turning an in-kind liquidation into a swap-based liquidation). For that purpose, the grace period duration need only be long enough for liquidation **bots** to act -- so 2 minutes is plenty. For borrowers, 2 minutes is almost certainly too short, as explained in the report below.

To address that, we are increasing the grace period to 5 minutes. In theory we could go even longer (as suggested in the report below) but we really don't want to increase the risk of bad debt, so we're being conservative.

Addresses
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/73