### PR TITLE
Switch from .transfer to solmate's safeTransferETH

### DIFF
--- a/core/src/Borrower.sol
+++ b/core/src/Borrower.sol
@@ -280,8 +280,9 @@ contract Borrower is IUniswapV3MintCallback {
             _repay(repayable0, repayable1);
             slot0 = (slot0_ & SLOT0_MASK_POSITIONS) | SLOT0_DIRT;
 
-            payable(callee).transfer(address(this).balance / strain);
             emit Liquidate(repayable0, repayable1, incentive1, priceX128);
+
+            SafeTransferLib.safeTransferETH(payable(callee), address(this).balance / strain);
         }
     }
 
@@ -431,7 +432,7 @@ contract Borrower is IUniswapV3MintCallback {
      */
     function withdrawAnte(address payable recipient) external onlyInModifyCallback {
         // WARNING: External call to user-specified address
-        recipient.transfer(address(this).balance);
+        SafeTransferLib.safeTransferETH(recipient, address(this).balance);
     }
 
     /**


### PR DESCRIPTION
Could theoretically make the protocol more resilient to Ethereum upgrades, if such upgrades increase the gas cost of ether transfers.

On the other hand, allows reentrancy. But CEI should keep us safe.

Addresses:
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/123
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/105
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/92
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/87
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/12
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/18
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/62
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/53
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/54