### PR TITLE
Increase CONSTRAINT_ANTE_MAX to 0.5 ether

### DIFF
--- a/core/src/libraries/constants/Constants.sol
+++ b/core/src/libraries/constants/Constants.sol
@@ -74,7 +74,7 @@ uint8 constant CONSTRAINT_RESERVE_FACTOR_MIN = 4;
 uint8 constant CONSTRAINT_RESERVE_FACTOR_MAX = 20;
 
 /// @dev The maximum amount of Ether that `Borrower`s can be required to post before taking on debt
-uint216 constant CONSTRAINT_ANTE_MAX = 0.1 ether;
+uint216 constant CONSTRAINT_ANTE_MAX = 0.5 ether;
 
 /*//////////////////////////////////////////////////////////////
                             LIQUIDATION


### PR DESCRIPTION
Addresses
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/83