### PR TITLE
Reduce manipulation attack surface of Volatility library

### DIFF
--- a/core/src/VolatilityOracle.sol
+++ b/core/src/VolatilityOracle.sol
@@ -43,6 +43,8 @@ contract VolatilityOracle {
     }
 
     function update(IUniswapV3Pool pool, uint40 seed) external returns (uint56, uint160, uint256) {
+        // TODO: require that sample for the current block hasn't been written to Uniswap observations,
+        // implying that nobody has added a bunch of liquidity to manipulate the sample
         unchecked {
             // Read `lastWrite` info from storage
             LastWrite memory lastWrite = lastWrites[pool];

--- a/core/src/libraries/Oracle.sol
+++ b/core/src/libraries/Oracle.sol
@@ -25,19 +25,18 @@ library Oracle {
      * @return sqrtMeanPriceX96 sqrt(TWAP) over the past `UNISWAP_AVG_WINDOW` seconds
      */
     function consult(IUniswapV3Pool pool, uint40 seed) internal view returns (uint56 metric, uint160 sqrtMeanPriceX96) {
-        (, int24 currentTick, uint16 observationIndex, uint16 observationCardinality, , , ) = pool.slot0();
-
         unchecked {
             int56[] memory tickCumulatives = new int56[](3);
-            uint160[] memory secondsPerLiquidityCumulativeX128s = new uint160[](3);
 
             if ((seed >> 32) > 0) {
                 uint32[] memory secondsAgos = new uint32[](3);
                 secondsAgos[0] = UNISWAP_AVG_WINDOW * 2;
                 secondsAgos[1] = UNISWAP_AVG_WINDOW;
                 secondsAgos[2] = 0;
-                (tickCumulatives, secondsPerLiquidityCumulativeX128s) = pool.observe(secondsAgos);
+                (tickCumulatives, ) = pool.observe(secondsAgos);
             } else {
+                (, int24 currentTick, uint16 observationIndex, uint16 observationCardinality, , , ) = pool.slot0();
+
                 (tickCumulatives[0], ) = observe(
                     pool,
                     uint32(block.timestamp - UNISWAP_AVG_WINDOW * 2),
@@ -46,7 +45,7 @@ library Oracle {
                     observationIndex,
                     observationCardinality
                 );
-                (tickCumulatives[1], secondsPerLiquidityCumulativeX128s[1]) = observe(
+                (tickCumulatives[1], ) = observe(
                     pool,
                     uint32(block.timestamp - UNISWAP_AVG_WINDOW),
                     seed % Q16,
@@ -54,7 +53,7 @@ library Oracle {
                     observationIndex,
                     observationCardinality
                 );
-                (tickCumulatives[2], secondsPerLiquidityCumulativeX128s[2]) = observe(
+                (tickCumulatives[2], ) = observe(
                     pool,
                     uint32(block.timestamp),
                     observationIndex,

--- a/core/src/libraries/Oracle.sol
+++ b/core/src/libraries/Oracle.sol
@@ -13,36 +13,19 @@ import {TickMath} from "./TickMath.sol";
 /// @author Aloe Labs, Inc.
 /// @author Modified from [Uniswap](https://github.com/Uniswap/v3-periphery/blob/main/contracts/libraries/OracleLibrary.sol)
 library Oracle {
-    struct PoolData {
-        // the current price (from pool.slot0())
-        uint160 sqrtPriceX96;
-        // the current tick (from pool.slot0())
-        int24 currentTick;
-        // the mean sqrt(price) over some period (OracleLibrary.consult() to get arithmeticMeanTick, then use TickMath)
-        uint160 sqrtMeanPriceX96;
-        // the mean liquidity over some period (OracleLibrary.consult())
-        uint160 secondsPerLiquidityX128;
-        // the number of seconds to look back when getting mean tick & mean liquidity
-        uint32 oracleLookback;
-        // the liquidity depth at currentTick (from pool.liquidity())
-        uint128 tickLiquidity;
-    }
-
     /**
      * @notice Calculates time-weighted means of tick and liquidity for a given Uniswap V3 pool
      * @param pool Address of the pool that we want to observe
      * @param seed The indices of `pool.observations` where we start our search for the 30-minute-old (lowest 16 bits)
      * and 60-minute-old (next 16 bits) observations. Determine these off-chain to make this method more efficient
      * than Uniswap's binary search. If any of the highest 8 bits are set, we fallback to onchain binary search.
-     * @return data An up-to-date `PoolData` struct containing all fields except `oracleLookback` and `tickLiquidity`
      * @return metric If the price was manipulated at any point in the past `UNISWAP_AVG_WINDOW` seconds, then at
      * some point in that period, this value will spike. It may still be high now, or (if the attacker is smart and
      * well-financed) it may have returned to nominal.
+     * @return sqrtMeanPriceX96 sqrt(TWAP) over the past `UNISWAP_AVG_WINDOW` seconds
      */
-    function consult(IUniswapV3Pool pool, uint40 seed) internal view returns (PoolData memory data, uint56 metric) {
-        uint16 observationIndex;
-        uint16 observationCardinality;
-        (data.sqrtPriceX96, data.currentTick, observationIndex, observationCardinality, , , ) = pool.slot0();
+    function consult(IUniswapV3Pool pool, uint40 seed) internal view returns (uint56 metric, uint160 sqrtMeanPriceX96) {
+        (, int24 currentTick, uint16 observationIndex, uint16 observationCardinality, , , ) = pool.slot0();
 
         unchecked {
             int56[] memory tickCumulatives = new int56[](3);
@@ -59,7 +42,7 @@ library Oracle {
                     pool,
                     uint32(block.timestamp - UNISWAP_AVG_WINDOW * 2),
                     seed >> 16,
-                    data.currentTick,
+                    currentTick,
                     observationIndex,
                     observationCardinality
                 );
@@ -67,7 +50,7 @@ library Oracle {
                     pool,
                     uint32(block.timestamp - UNISWAP_AVG_WINDOW),
                     seed % Q16,
-                    data.currentTick,
+                    currentTick,
                     observationIndex,
                     observationCardinality
                 );
@@ -75,15 +58,11 @@ library Oracle {
                     pool,
                     uint32(block.timestamp),
                     observationIndex,
-                    data.currentTick,
+                    currentTick,
                     observationIndex,
                     observationCardinality
                 );
             }
-
-            data.secondsPerLiquidityX128 =
-                secondsPerLiquidityCumulativeX128s[2] -
-                secondsPerLiquidityCumulativeX128s[1];
 
             // Compute arithmetic mean tick over `UNISWAP_AVG_WINDOW`, always rounding down to -inf
             int256 delta = tickCumulatives[2] - tickCumulatives[1];
@@ -92,7 +71,7 @@ library Oracle {
                 // Equivalent: if (delta < 0 && (delta % UNISWAP_AVG_WINDOW != 0)) meanTick0ToW--;
                 meanTick0ToW := sub(meanTick0ToW, and(slt(delta, 0), iszero(iszero(smod(delta, UNISWAP_AVG_WINDOW)))))
             }
-            data.sqrtMeanPriceX96 = TickMath.getSqrtRatioAtTick(int24(meanTick0ToW));
+            sqrtMeanPriceX96 = TickMath.getSqrtRatioAtTick(int24(meanTick0ToW));
 
             // Compute arithmetic mean tick over the interval [-2w, 0)
             int256 meanTick0To2W = (tickCumulatives[2] - tickCumulatives[0]) / int32(UNISWAP_AVG_WINDOW * 2);

--- a/core/src/libraries/Volatility.sol
+++ b/core/src/libraries/Volatility.sol
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.17;
 
-import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {FixedPointMathLib as SoladyMath} from "solady/utils/FixedPointMathLib.sol";
-
-import {square, mulDiv96, mulDiv128} from "./MulDiv.sol";
-import {Oracle} from "./Oracle.sol";
 
 /// @title Volatility
 /// @notice Provides functions that use Uniswap v3 to compute price volatility
 /// @author Aloe Labs, Inc.
 library Volatility {
+    using SoladyMath for uint256;
+
     struct PoolMetadata {
         // the overall fee minus the protocol fee for token0, times 1e6
         uint24 gamma0;
@@ -29,12 +27,15 @@ library Volatility {
         uint32 timestamp;
     }
 
+    uint256 private constant _Q224Div1e18 = (uint256(1 << 224) * 1e6) / 1e24; // solhint-disable const-name-snakecase
+    uint256 private constant _Q128Div1e18 = (uint256(1 << 128) * 1e6) / 1e24; // solhint-disable const-name-snakecase
+
     /**
      * @notice Estimates implied volatility using
      * [this math](https://lambert-guillaume.medium.com/on-chain-volatility-and-uniswap-v3-d031b98143d1).
      * @dev The return value can fit in uint128 if necessary
      * @param metadata The pool's metadata (may be cached)
-     * @param data A summary of the pool's state from `pool.slot0` `pool.observe` and `pool.liquidity`
+     * @param sqrtMeanPriceX96 sqrt(TWAP) over some period. Likely from `Oracle.consult`
      * @param a The pool's cumulative feeGrowthGlobals some time in the past
      * @param b The pool's cumulative feeGrowthGlobals as of the current block
      * @param scale The timescale (in seconds) in which IV should be reported, e.g. hourly, daily, annualized
@@ -42,98 +43,46 @@ library Volatility {
      */
     function estimate(
         PoolMetadata memory metadata,
-        Oracle.PoolData memory data,
+        uint160 sqrtMeanPriceX96,
         FeeGrowthGlobals memory a,
         FeeGrowthGlobals memory b,
         uint32 scale
     ) internal pure returns (uint256) {
-        uint256 tickTvl = computeTickTvl(metadata.tickSpacing, data.sqrtPriceX96, data.tickLiquidity);
-
-        // Return early to avoid division by 0
-        if (data.secondsPerLiquidityX128 == 0 || b.timestamp - a.timestamp == 0 || tickTvl == 0) return 0;
-
-        uint256 revenue0Gamma1 = computeRevenueGamma(
-            a.feeGrowthGlobal0X128,
-            b.feeGrowthGlobal0X128,
-            data.secondsPerLiquidityX128,
-            data.oracleLookback,
-            metadata.gamma1
-        );
-        uint256 revenue1Gamma0 = computeRevenueGamma(
-            a.feeGrowthGlobal1X128,
-            b.feeGrowthGlobal1X128,
-            data.secondsPerLiquidityX128,
-            data.oracleLookback,
-            metadata.gamma0
-        );
-        // This is an approximation. Ideally the fees earned during each swap would be multiplied by the price
-        // *at that swap*. But for prices simulated with GBM and swap sizes either normally or uniformly distributed,
-        // the error you get from using geometric mean price is <1% even with high drift and volatility.
-        uint256 volumeGamma0Gamma1 = revenue1Gamma0 + amount0ToAmount1(revenue0Gamma1, data.sqrtMeanPriceX96);
-        // Clamp to prevent overflow later on
-        if (volumeGamma0Gamma1 > (1 << 128)) volumeGamma0Gamma1 = (1 << 128);
-
         unchecked {
-            // Scale volume to the target time frame, divide by `tickTvl`, and sqrt for final result
-            return SoladyMath.sqrt((4e24 * volumeGamma0Gamma1 * scale) / (b.timestamp - a.timestamp) / tickTvl);
-        }
-    }
+            // Return early to avoid division by 0
+            if (b.timestamp - a.timestamp == 0) return 0;
 
-    /**
-     * @notice Computes an `amount1` that (at `tick`) is equivalent in worth to the provided `amount0`
-     * @param amount0 The amount of token0 to convert
-     * @param sqrtPriceX96 The sqrt(price) at which the conversion should hold true
-     * @return amount1 An equivalent amount of token1
-     */
-    function amount0ToAmount1(uint256 amount0, uint160 sqrtPriceX96) internal pure returns (uint256 amount1) {
-        uint256 priceX128 = square(sqrtPriceX96);
-        amount1 = mulDiv128(amount0, priceX128);
-    }
+            // Goal:  IV = 2γ √(volume / valueOfLiquidity)
+            //
+            //  γ = √(γ₀γ₁)
+            //  volume ≈ ((P · fgg0 / γ₀) + (fgg1 / γ₁)) · liquidity
+            //  valueOfLiquidity = (tickSpacing · liquidity · √P) / 20000
+            //
+            //        IV = 2 √( 20000 · γ₀γ₁ · ((P · fgg0 / γ₀) + (fgg1 / γ₁)) / √P / tickSpacing )
+            //           = 2 √( 20000 ·        ((P · fgg0 · γ₁) + (fgg1 · γ₀)) / √P / tickSpacing )
+            //           = 2 √( 20000 ·        (fgg0 · γ₁ · √P  +  fgg1 · γ₀ / √P)  / tickSpacing )
 
-    /**
-     * @notice Computes pool revenue using feeGrowthGlobal accumulators, then scales it down by a factor of gamma
-     * @param feeGrowthGlobalAX128 The value of feeGrowthGlobal (either 0 or 1) at time A
-     * @param feeGrowthGlobalBX128 The value of feeGrowthGlobal (either 0 or 1, but matching) at time B (B > A)
-     * @param secondsPerLiquidityX128 The difference in the secondsPerLiquidity accumulator from `secondsAgo` seconds ago until now
-     * @param secondsAgo The oracle lookback period that was used to find `secondsPerLiquidityX128`
-     * @param gamma The fee factor to scale by
-     * @return Revenue over the period from `block.timestamp - secondsAgo` to `block.timestamp`, scaled down by a factor of gamma
-     */
-    function computeRevenueGamma(
-        uint256 feeGrowthGlobalAX128,
-        uint256 feeGrowthGlobalBX128,
-        uint160 secondsPerLiquidityX128,
-        uint32 secondsAgo,
-        uint24 gamma
-    ) internal pure returns (uint256) {
-        unchecked {
-            uint256 delta;
+            // Calculate average [fees per unit of liquidity] for this time period
+            uint256 fgg0X128 = b.feeGrowthGlobal0X128 - a.feeGrowthGlobal0X128;
+            uint256 fgg1X128 = b.feeGrowthGlobal1X128 - a.feeGrowthGlobal1X128;
 
-            if (feeGrowthGlobalBX128 >= feeGrowthGlobalAX128) {
-                // feeGrowthGlobal has increased from time A to time B
-                delta = feeGrowthGlobalBX128 - feeGrowthGlobalAX128;
-            } else {
-                // feeGrowthGlobal has overflowed between time A and time B
-                delta = type(uint256).max - feeGrowthGlobalAX128 + feeGrowthGlobalBX128;
-            }
+            // Start math.
+            // Also remove Q128 and instead scale by 1e24 (gammas have 1e6, and we pull 1e18 out of the denominator).
+            uint256 fgg0Gamma1MulP = fgg0X128.fullMulDiv(uint256(metadata.gamma1) * sqrtMeanPriceX96, _Q224Div1e18);
+            uint256 fgg1Gamma0DivP = fgg1X128.fullMulDiv(
+                uint256(metadata.gamma0) << 96,
+                sqrtMeanPriceX96 * _Q128Div1e18
+            );
 
-            return Math.mulDiv(delta, secondsAgo * uint256(gamma), secondsPerLiquidityX128 * uint256(1e6));
-        }
-    }
+            // Make sure numerator won't overflow in the next step
+            uint256 inner = (fgg0Gamma1MulP + fgg1Gamma0DivP).min(uint256(1 << 224) / 20_000);
 
-    /**
-     * @notice Computes the value of liquidity available at the current tick, denominated in token1
-     * @param tickSpacing The pool tick spacing (from pool.tickSpacing())
-     * @param sqrtPriceX96 The current price (from pool.slot0())
-     * @param liquidity The liquidity depth at currentTick (from pool.liquidity())
-     */
-    function computeTickTvl(
-        int24 tickSpacing,
-        uint160 sqrtPriceX96,
-        uint128 liquidity
-    ) internal pure returns (uint256 tickTvl) {
-        unchecked {
-            tickTvl = SoladyMath.rawDiv(mulDiv96(uint256(uint24(tickSpacing)) * liquidity, sqrtPriceX96), 20_000);
+            // Finish math and adjust to specified timescale
+            return
+                2 *
+                SoladyMath.sqrt(
+                    (20_000 * inner * scale) / (b.timestamp - a.timestamp) / uint256(int256(metadata.tickSpacing))
+                );
         }
     }
 }

--- a/core/test/Utils.sol
+++ b/core/test/Utils.sol
@@ -52,8 +52,8 @@ contract VolatilityOracleMock {
     function prepare(IUniswapV3Pool pool) external {}
 
     function consult(IUniswapV3Pool pool, uint40 seed) external view returns (uint56, uint160, uint256) {
-        (Oracle.PoolData memory data, uint56 metric) = Oracle.consult(pool, seed);
-        return (metric, data.sqrtMeanPriceX96, 0.025e12);
+        (uint56 metric, uint160 sqrtMeanPriceX96) = Oracle.consult(pool, seed);
+        return (metric, sqrtMeanPriceX96, 0.025e12);
     }
 }
 

--- a/core/test/VolatilityOracle.t.sol
+++ b/core/test/VolatilityOracle.t.sol
@@ -211,7 +211,7 @@ contract VolatilityOracleTest is Test {
             (uint56 metric, uint160 sqrtPriceX96, uint256 iv) = oracle.update(pool, (1 << 32));
             totalGas += g - gasleft();
 
-            console2.log(block.timestamp, sqrtPriceX96, iv, metric);
+            console2.log(block.timestamp, metric, sqrtPriceX96, iv);
         }
 
         console2.log("avg gas to update oracle:", totalGas / 600);

--- a/core/test/libraries/Volatility.t.sol
+++ b/core/test/libraries/Volatility.t.sol
@@ -6,24 +6,17 @@ import "forge-std/Test.sol";
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 
 import {TickMath} from "src/libraries/TickMath.sol";
-import {Volatility, Oracle, mulDiv96} from "src/libraries/Volatility.sol";
+import {Volatility, mulDiv96} from "src/libraries/Volatility.sol";
 
 contract VolatilityTest is Test {
     function setUp() public {}
 
     function test_spec_estimate() public {
         Volatility.PoolMetadata memory metadata = Volatility.PoolMetadata(3000, 3000, 60);
-        Oracle.PoolData memory data = Oracle.PoolData(
-            1278673744380353403099539498152303, // sqrtPriceX96
-            193789, // currentTick
-            TickMath.getSqrtRatioAtTick(193730), // arithmeticMeanTick
-            44521837137365694357186, // _secondsPerLiquidityX128
-            3600, // _oracleLookback
-            19685271204911047580 // poolLiquidity
-        );
+        uint160 sqrtMeanPriceX96 = TickMath.getSqrtRatioAtTick(193730);
         uint256 dailyIV = Volatility.estimate(
             metadata,
-            data,
+            sqrtMeanPriceX96,
             Volatility.FeeGrowthGlobals(
                 1501955347902231987349614320458936,
                 527278396421895291380335427321388844898052,
@@ -36,11 +29,11 @@ contract VolatilityTest is Test {
             ),
             1 days
         );
-        assertEq(dailyIV, 20394487700); // 2.039%
+        assertEq(dailyIV, 17276173878);
 
         dailyIV = Volatility.estimate(
             metadata,
-            data,
+            sqrtMeanPriceX96,
             Volatility.FeeGrowthGlobals(
                 1501955347902231987349614320458936,
                 527278396421895291380335427321388844898052,
@@ -53,11 +46,11 @@ contract VolatilityTest is Test {
             ),
             1 hours
         );
-        assertEq(dailyIV, 4163007369); // 0.416%
+        assertEq(dailyIV, 3526484226);
 
         dailyIV = Volatility.estimate(
             metadata,
-            data,
+            sqrtMeanPriceX96,
             Volatility.FeeGrowthGlobals(0, 0, 0),
             Volatility.FeeGrowthGlobals(
                 1501968291161650295867029090958139,
@@ -66,11 +59,11 @@ contract VolatilityTest is Test {
             ),
             1 days
         );
-        assertEq(dailyIV, 6966343817); // 0.696%
+        assertEq(dailyIV, 5901190938);
 
         dailyIV = Volatility.estimate(
             metadata,
-            data,
+            sqrtMeanPriceX96,
             Volatility.FeeGrowthGlobals(
                 1501955347902231987349614320458936,
                 527278396421895291380335427321388844898052,
@@ -83,11 +76,11 @@ contract VolatilityTest is Test {
             ),
             1 days
         );
-        assertEq(dailyIV, 0); // 0%
+        assertEq(dailyIV, 0);
 
         dailyIV = Volatility.estimate(
             metadata,
-            data,
+            sqrtMeanPriceX96,
             Volatility.FeeGrowthGlobals(
                 1501955347902231987349614320458936,
                 527278396421895291380335427321388844898052,
@@ -100,141 +93,10 @@ contract VolatilityTest is Test {
             ),
             1 days
         );
-        assertEq(dailyIV, 0); // 0%
-    }
-
-    function test_spec_amount0ToAmount1() public {
-        uint256 amount1;
-
-        amount1 = Volatility.amount0ToAmount1(0, TickMath.getSqrtRatioAtTick(1000));
-        assertEq(amount1, 0);
-        amount1 = Volatility.amount0ToAmount1(0, TickMath.getSqrtRatioAtTick(-1000));
-        assertEq(amount1, 0);
-        amount1 = Volatility.amount0ToAmount1(type(uint128).max, TickMath.getSqrtRatioAtTick(1000));
-        assertEq(amount1, 376068295634136240002369832473867089913);
-        amount1 = Volatility.amount0ToAmount1(type(uint128).max, TickMath.getSqrtRatioAtTick(-1000));
-        assertEq(amount1, 307901757690220954445983032426865855048);
-        amount1 = Volatility.amount0ToAmount1(4000000000, TickMath.getSqrtRatioAtTick(193325)); // ~ 4000 USDC
-        assertEq(amount1, 994576722964113793); // ~ 1 ETH
-    }
-
-    function test_fuzz_amount0ToAmount1(uint128 amount0, int24 tick) public {
-        tick = int24(bound(tick, -100000, 100000));
-        uint160 sqrtPriceX96 = TickMath.getSqrtRatioAtTick(tick);
-        uint256 amount1 = Volatility.amount0ToAmount1(amount0, sqrtPriceX96);
-
-        if (amount0 == 0) {
-            assertEq(amount1, 0);
-            return;
-        }
-        if (amount0 < 1e6) return;
-
-        uint256 priceX128Actual = Math.mulDiv(amount1, 2 ** 128, amount0);
-        uint256 priceX128Expected = Math.mulDiv(sqrtPriceX96, sqrtPriceX96, 2 ** 64);
-
-        assertApproxEqRel(priceX128Actual, priceX128Expected, 0.01e18);
-    }
-
-    function test_spec_computeRevenueGamma() public {
-        uint256 revenueGamma = Volatility.computeRevenueGamma(11111111111, 222222222222, 3975297179, 5000, 100);
-        assertEq(revenueGamma, 26);
-    }
-
-    function test_spec_computeTickTvl() public {
-        uint256 tickTvl;
-        tickTvl = Volatility.computeTickTvl(1, TickMath.getSqrtRatioAtTick(19000), 100000000000);
-        assertEq(tickTvl, 12927934);
-        tickTvl = Volatility.computeTickTvl(10, TickMath.getSqrtRatioAtTick(19000), 9763248618769789);
-        assertEq(tickTvl, 12621863617134);
-        tickTvl = Volatility.computeTickTvl(60, TickMath.getSqrtRatioAtTick(-19000), 100000000000);
-        assertEq(tickTvl, 116027817);
-        tickTvl = Volatility.computeTickTvl(60, TickMath.getSqrtRatioAtTick(-3000), 999999999);
-        assertEq(tickTvl, 2582143);
-    }
-
-    function test_comparitive_computeTickTvl(int24 tick, uint128 liquidity) public {
-        tick = int24(bound(tick, TickMath.MIN_TICK, TickMath.MAX_TICK));
-        uint160 sqrtPriceX96 = TickMath.getSqrtRatioAtTick(tick);
-
-        int24[4] memory tickSpacings = [int24(1), 10, 60, 100];
-        for (uint256 i; i < 4; i++) {
-            uint256 a = Volatility.computeTickTvl(tickSpacings[i], sqrtPriceX96, liquidity);
-            uint256 b = _computeTickTvlOriginal(tickSpacings[i], tick, sqrtPriceX96, liquidity);
-            assertGe(a, b);
-            if (b > 1000) assertApproxEqRel(a, b, 0.005e18);
-        }
-    }
-
-    function test_fuzz_computeTickTvl(int24 currentTick, uint8 tickSpacing, uint128 tickLiquidity) public {
-        if (tickSpacing == 0) return; // Always true in the real world
-        int24 _tickSpacing = int24(uint24(tickSpacing));
-
-        if (currentTick < TickMath.MIN_TICK) currentTick = TickMath.MIN_TICK + _tickSpacing;
-        if (currentTick > TickMath.MAX_TICK) currentTick = TickMath.MAX_TICK - _tickSpacing;
-        uint160 sqrtPriceX96 = TickMath.getSqrtRatioAtTick(currentTick);
-
-        // Ensure it doesn't revert
-        uint256 tickTvl = Volatility.computeTickTvl(_tickSpacing, sqrtPriceX96, tickLiquidity);
-
-        // Check that it's non-zero in cases where we don't expect truncation
-        int24 lowerBound = TickMath.MIN_TICK / 2;
-        int24 upperBound = TickMath.MAX_TICK / 2;
-        if (tickLiquidity > 1_000_000 && currentTick < lowerBound && currentTick > upperBound) assertGt(tickTvl, 0);
-    }
-
-    function test_fuzz_computeTickTvlDoesNotRevert(uint8 tier, int24 tick, uint128 liquidity) public pure {
-        int24 tickSpacing;
-        tier = tier % 4;
-        if (tier == 0) tickSpacing = 1;
-        else if (tier == 1) tickSpacing = 10;
-        else if (tier == 2) tickSpacing = 60;
-        else if (tier == 3) tickSpacing = 100;
-
-        if (tick < TickMath.MIN_TICK + tickSpacing) tick = TickMath.MIN_TICK + tickSpacing;
-        else if (tick > TickMath.MAX_TICK - tickSpacing) tick = TickMath.MAX_TICK - tickSpacing;
-
-        uint160 sqrtPriceX96 = TickMath.getSqrtRatioAtTick(tick);
-
-        Volatility.computeTickTvl(tickSpacing, sqrtPriceX96, liquidity);
-    }
-
-    function test_fuzz_computeRevenueGammaDoesNotRevertA(
-        uint256 feeGrowthGlobalAX128,
-        uint256 feeGrowthGlobalBX128,
-        uint160 secondsPerLiquidityX128
-    ) public pure {
-        if (secondsPerLiquidityX128 == 0) return;
-        Volatility.computeRevenueGamma(feeGrowthGlobalAX128, feeGrowthGlobalBX128, secondsPerLiquidityX128, 5000, 100);
-    }
-
-    function test_fuzz_computeRevenueGammaDoesNotRevertB(
-        uint256 feeGrowthGlobalAX128,
-        uint224 feeGrowthGlobalDeltaX128,
-        uint160 secondsPerLiquidityX128,
-        uint32 secondsAgo,
-        uint24 gamma
-    ) public pure {
-        // NOTE: Important assumption here, since this value only changes when ticks are crossed!
-        vm.assume(secondsPerLiquidityX128 != 0);
-
-        gamma = gamma % 1e6;
-
-        uint256 feeGrowthGlobalBX128;
-        unchecked {
-            feeGrowthGlobalBX128 = feeGrowthGlobalAX128 + feeGrowthGlobalDeltaX128;
-        }
-
-        Volatility.computeRevenueGamma(
-            feeGrowthGlobalAX128,
-            feeGrowthGlobalBX128,
-            secondsPerLiquidityX128,
-            secondsAgo,
-            gamma
-        );
+        assertEq(dailyIV, 0);
     }
 
     function test_fuzz_estimateDoesNotRevertA(
-        uint128 tickLiquidity,
         int16 tick,
         int8 tickMeanOffset,
         uint192 a,
@@ -243,17 +105,9 @@ contract VolatilityTest is Test {
         uint48 d
     ) public pure {
         Volatility.PoolMetadata memory metadata = Volatility.PoolMetadata(3000, 3000, 60);
-        Oracle.PoolData memory data = Oracle.PoolData(
-            TickMath.getSqrtRatioAtTick(tick), // sqrtPriceX96
-            tick, // currentTick
-            TickMath.getSqrtRatioAtTick(tick + int24(tickMeanOffset)), // arithmeticMeanTick
-            44521837137365694357186, // secondsPerLiquidityX128
-            3600, // oracleLookback
-            tickLiquidity // tickLiquidity
-        );
         Volatility.estimate(
             metadata,
-            data,
+            TickMath.getSqrtRatioAtTick(tick + int24(tickMeanOffset)),
             Volatility.FeeGrowthGlobals(a, b, 0),
             Volatility.FeeGrowthGlobals(uint256(a) + uint256(c), uint256(b) + uint256(d), 7777),
             1 days
@@ -267,16 +121,10 @@ contract VolatilityTest is Test {
         uint96 feeGrowthGlobalDelta0X128,
         uint128 feeGrowthGlobalDelta1X128,
         uint48 gammas,
-        int24 tick,
         int24 arithmeticMeanTick,
-        uint160 secondsPerLiquidityX128,
-        uint32 oracleLookback,
-        uint128 tickLiquidity,
         uint32 scale
     ) public {
         scale = uint32(bound(scale, 1 minutes, 2 days));
-        oracleLookback = uint32(bound(oracleLookback, 15 seconds, 1 days));
-        secondsPerLiquidityX128 = uint160(bound(secondsPerLiquidityX128, feeGrowthSampleAge, type(uint160).max));
 
         Volatility.PoolMetadata memory metadata = Volatility.PoolMetadata(
             uint24(gammas % (1 << 24)),
@@ -292,16 +140,7 @@ contract VolatilityTest is Test {
             else if (tier == 3) metadata.tickSpacing = 100;
         }
 
-        tick = _boundTick(tick, metadata.tickSpacing);
         arithmeticMeanTick = _boundTick(arithmeticMeanTick, metadata.tickSpacing);
-        Oracle.PoolData memory data = Oracle.PoolData(
-            TickMath.getSqrtRatioAtTick(tick),
-            tick,
-            TickMath.getSqrtRatioAtTick(arithmeticMeanTick),
-            secondsPerLiquidityX128,
-            oracleLookback,
-            tickLiquidity
-        );
 
         Volatility.FeeGrowthGlobals memory a;
         Volatility.FeeGrowthGlobals memory b;
@@ -314,47 +153,12 @@ contract VolatilityTest is Test {
             b.timestamp = feeGrowthSampleAge;
         }
 
-        assertLt(Volatility.estimate(metadata, data, a, b, scale), 1 << 128);
+        assertLt(Volatility.estimate(metadata, TickMath.getSqrtRatioAtTick(arithmeticMeanTick), a, b, scale), 1 << 128);
     }
 
     function _boundTick(int24 tick, int24 tickSpacing) private pure returns (int24) {
         if (tick < TickMath.MIN_TICK + tickSpacing) return TickMath.MIN_TICK + tickSpacing;
         else if (tick > TickMath.MAX_TICK - tickSpacing) return TickMath.MAX_TICK - tickSpacing;
         else return tick;
-    }
-
-    function _computeTickTvlOriginal(
-        int24 tickSpacing,
-        int24 tick,
-        uint160 sqrtPriceX96,
-        uint128 liquidity
-    ) internal pure returns (uint256 tickTvl) {
-        unchecked {
-            tick = TickMath.floor(tick, tickSpacing);
-
-            tickTvl = _getValueOfLiquidity(
-                sqrtPriceX96,
-                TickMath.getSqrtRatioAtTick(tick),
-                TickMath.getSqrtRatioAtTick(tick + tickSpacing),
-                liquidity
-            );
-        }
-    }
-
-    function _getValueOfLiquidity(
-        uint160 sqrtRatioX96,
-        uint160 sqrtRatioAX96,
-        uint160 sqrtRatioBX96,
-        uint128 liquidity
-    ) private pure returns (uint256 value) {
-        assert(sqrtRatioAX96 <= sqrtRatioX96 && sqrtRatioX96 <= sqrtRatioBX96);
-
-        unchecked {
-            uint256 numerator = Math.mulDiv(uint256(liquidity) << 128, sqrtRatioX96, sqrtRatioBX96);
-
-            value =
-                Math.mulDiv(numerator, sqrtRatioBX96 - sqrtRatioX96, (1 << 224)) +
-                mulDiv96(liquidity, sqrtRatioX96 - sqrtRatioAX96);
-        }
     }
 }

--- a/core/test/libraries/Volatility.t.sol
+++ b/core/test/libraries/Volatility.t.sol
@@ -6,7 +6,7 @@ import "forge-std/Test.sol";
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 
 import {TickMath} from "src/libraries/TickMath.sol";
-import {Volatility, mulDiv96} from "src/libraries/Volatility.sol";
+import {Volatility} from "src/libraries/Volatility.sol";
 
 contract VolatilityTest is Test {
     function setUp() public {}


### PR DESCRIPTION
The IV formula requires us to compute the value of liquidity at the "current" tick. Mathematically, the most correct way of doing that is to look at `pool.slot0().sqrtPriceX96` and `pool.liquidity()`, which is what we did previously. However, those values are manipulatable, and it turns out that using the geometric mean price and the harmonic mean liquidity give approximately the same results. Moreover, since we were already using these mean values to get Fee Volume in the numerator, they end up cancelling out and simplifying the math.

The IV estimate is now based purely on `feeGrowthGlobals` and the TWAP. Since `feeGrowthGlobals` are themselves manipulatable (albeit at a cost), further work could include reducing `IV_CHANGE_PER_UPDATE`, using a median fee growth value over many samples, or both.

Addresses
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/63
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/109
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/125

<img width="819" alt="image" src="https://github.com/aloelabs/aloe-ii/assets/17186559/6ffc5021-cd38-4d23-ad39-923bc0a5492c">

Other IV issues that this does **not** yet address
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/38
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/45
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/91