### PR TITLE
Remove flash() function from Lender

### DIFF
--- a/core/src/Lender.sol
+++ b/core/src/Lender.sol
@@ -12,10 +12,6 @@ import {Rewards} from "./libraries/Rewards.sol";
 import {Ledger} from "./Ledger.sol";
 import {IRateModel} from "./RateModel.sol";
 
-interface IFlashBorrower {
-    function onFlashLoan(address initiator, uint256 amount, bytes calldata data) external;
-}
-
 /// @title Lender
 /// @author Aloe Labs, Inc.
 /// @dev "Test everything; hold fast what is good." - 1 Thessalonians 5:21
@@ -284,28 +280,6 @@ contract Lender is Ledger {
         require(cache.lastBalance <= asset().balanceOf(address(this)), "Aloe: insufficient pre-pay");
 
         emit Repay(msg.sender, beneficiary, amount, units);
-    }
-
-    /**
-     * @notice Gives `to` temporary control over `amount` of `asset` in the `IFlashBorrower.onFlashLoan` callback.
-     * Arbitrary `data` can be forwarded to the callback. Before returning, the `IFlashBorrower` must have sent
-     * at least `amount` back to this contract.
-     * @dev Reentrancy guard is critical here! Without it, one could use a flash loan to repay a normal loan.
-     */
-    function flash(uint256 amount, IFlashBorrower to, bytes calldata data) external {
-        // Guard against reentrancy
-        uint32 lastAccrualTime_ = lastAccrualTime;
-        require(lastAccrualTime_ != 0, "Aloe: locked");
-        lastAccrualTime = 0;
-
-        ERC20 asset_ = asset();
-
-        uint256 balance = asset_.balanceOf(address(this));
-        asset_.safeTransfer(address(to), amount);
-        to.onFlashLoan(msg.sender, amount, data);
-        require(balance <= asset_.balanceOf(address(this)), "Aloe: insufficient pre-pay");
-
-        lastAccrualTime = lastAccrualTime_;
     }
 
     function accrueInterest() external returns (uint72) {

--- a/core/test/invariants/LenderHarness.sol
+++ b/core/test/invariants/LenderHarness.sol
@@ -8,15 +8,6 @@ import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 import {Factory} from "src/Factory.sol";
 import "src/Lender.sol";
 
-contract FlashBorrower is IFlashBorrower {
-    function onFlashLoan(address, uint256, bytes calldata data) external {
-        Lender lender = Lender(msg.sender);
-
-        require(lender.lastAccrualTime() == 0, "flash: broken reentrancy lock");
-        lender.asset().transfer(msg.sender, abi.decode(data, (uint256)));
-    }
-}
-
 // TODO: Add expectEmit
 // TODO: test non-prepaying versions
 // TODO: combine with ERC4626 invariants
@@ -25,8 +16,6 @@ contract LenderHarness {
     Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     Lender immutable LENDER;
-
-    FlashBorrower immutable FLASH_BORROWER;
 
     address[] public holders;
 
@@ -44,7 +33,6 @@ contract LenderHarness {
 
     constructor(Lender lender) {
         LENDER = lender;
-        FLASH_BORROWER = new FlashBorrower();
 
         holders.push(lender.RESERVE());
         alreadyHolder[lender.RESERVE()] = true;
@@ -426,24 +414,6 @@ contract LenderHarness {
         );
 
         return units;
-    }
-
-    /// @notice Initiates a flash loan from `msg.sender`, requesting that `amountOut` tokens be sent to `FLASH_BORROWER`
-    function flash(uint256 amountOut, uint256 amountIn) public {
-        // Check that `LENDER` actually has `amount` available for borrowing
-        uint256 maxFlash = LENDER.asset().balanceOf(address(LENDER));
-        amountOut = amountOut % (maxFlash + 1);
-
-        // Expect revert if `to` doesn't repay enough
-        if (amountOut > 0) {
-            vm.prank(msg.sender);
-            vm.expectRevert(bytes("Aloe: insufficient pre-pay"));
-            LENDER.flash(amountOut, FLASH_BORROWER, abi.encode(amountIn % amountOut));
-        }
-
-        // Actual action
-        vm.prank(msg.sender);
-        LENDER.flash(amountOut, FLASH_BORROWER, abi.encode(amountOut));
     }
 
     /// @notice Sends `shares` from `msg.sender` to `to`


### PR DESCRIPTION
Though we have no reason to think that `flash` is insecure or vulnerable, it doesn't really serve a purpose within the protocol. And since the flash loans were free, they weren't benefitting lenders. So in an abundance of caution and to reduce attack surface, we're removing it.