### PR TITLE
Add correct accounting for courier rewards

### DIFF
--- a/core/src/Factory.sol
+++ b/core/src/Factory.sol
@@ -129,9 +129,6 @@ contract Factory {
     /// @notice Returns the `Courier` for any given ID
     mapping(uint32 => Courier) public couriers;
 
-    /// @notice Returns whether the given address has enrolled as a courier
-    mapping(address => bool) public isCourier;
-
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
@@ -226,10 +223,6 @@ contract Factory {
     //////////////////////////////////////////////////////////////*/
 
     function claimRewards(Lender[] calldata lenders, address beneficiary) external returns (uint256 earned) {
-        // Couriers cannot claim rewards because the accounting isn't quite correct for them. Specifically, we
-        // save gas by omitting a `Rewards.updateUserState` call for the courier in `Lender._burn`
-        require(!isCourier[msg.sender]);
-
         unchecked {
             uint256 count = lenders.length;
             for (uint256 i = 0; i < count; i++) {
@@ -260,8 +253,6 @@ contract Factory {
         require(couriers[id].cut == 0);
 
         couriers[id] = Courier(msg.sender, cut);
-        isCourier[msg.sender] = true;
-
         emit EnrollCourier(id, msg.sender, cut);
     }
 

--- a/core/src/Lender.sol
+++ b/core/src/Lender.sol
@@ -510,15 +510,12 @@ contract Lender is Ledger {
                     // Compute portion of fee to pay out during this burn.
                     fee = (fee * shares) / balance;
 
-                    // Send `fee` from `from` to `courier.wallet`.
+                    // Send `fee` from `from` to `courier`.
                     // NOTE: We skip principle update on courier, so if couriers credit
                     // each other, 100% of `fee` is treated as profit and will pass through
                     // to the next courier.
-                    // NOTE: We skip rewards update on the courier. This means accounting isn't
-                    // accurate for them, so they *should not* be allowed to claim rewards. This
-                    // slightly reduces the effective overall rewards rate.
                     data -= fee;
-                    balances[courier] += fee;
+                    Rewards.updateUserState(s, a, courier, (balances[courier] += fee) - fee);
                     emit Transfer(from, courier, fee);
                 }
 

--- a/core/test/Factory.t.sol
+++ b/core/test/Factory.t.sol
@@ -101,7 +101,6 @@ contract FactoryTest is Test {
         emit EnrollCourier(id, address(this), cut);
         factory.enrollCourier(id, cut);
 
-        assertTrue(factory.isCourier(address(this)));
         (address courier, uint16 cutRec) = factory.couriers(id);
         assertEq(courier, address(this));
         assertEq(cutRec, cut);
@@ -114,13 +113,6 @@ contract FactoryTest is Test {
         Lender[] memory lenders = new Lender[](2);
         lenders[0] = lender0;
         lenders[1] = lender1;
-
-        // Couriers cannot claim rewards
-        vm.prank(address(6789));
-        factory.enrollCourier(1, 5000);
-        vm.prank(address(6789));
-        vm.expectRevert(bytes(""));
-        factory.claimRewards(lenders, address(6789));
 
         // Set rewards token
         vm.prank(factory.GOVERNOR());


### PR DESCRIPTION
Addresses
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/147
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/134
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/118
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/151
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/14