### PR TITLE
Replace RESERVE inflation with new erase() function in Lender

### DIFF
--- a/core/script/Deploy.s.sol
+++ b/core/script/Deploy.s.sol
@@ -9,7 +9,6 @@ import {RateModel} from "src/RateModel.sol";
 import {VolatilityOracle} from "src/VolatilityOracle.sol";
 
 address constant GOVERNOR = 0x2bf8eA41aF0695D482C4aa23d4f8aD7E9023b890;
-address constant RESERVE = 0xAd236E154cbC33cFDB6CD7A4BA04679d9fb74A8C;
 
 // Derived using https://github.com/0age/create2crunch/
 bytes32 constant saltA = 0x0000000000000000000000000000000000000000aeeec55d74c86000021e5622;
@@ -29,7 +28,7 @@ contract DeployScript is Script {
 
         bytes32 ichFactory = hashInitCode(
             type(Factory).creationCode,
-            abi.encode(GOVERNOR, RESERVE, addrVolatilityOracle, addrBorrowerDeployer, addrRateModel)
+            abi.encode(GOVERNOR, addrVolatilityOracle, addrBorrowerDeployer, addrRateModel)
         );
         address addrFactory = computeCreate2Address(saltD, ichFactory);
 
@@ -52,7 +51,6 @@ contract DeployScript is Script {
         BorrowerDeployer borrowerDeployer = new BorrowerDeployer{salt: saltC}();
         Factory factory = new Factory{salt: saltD}({
             governor: GOVERNOR,
-            reserve: RESERVE,
             oracle: oracle,
             borrowerDeployer: borrowerDeployer,
             defaultRateModel: rateModel

--- a/core/src/Factory.sol
+++ b/core/src/Factory.sol
@@ -9,13 +9,10 @@ import {
     DEFAULT_ANTE,
     DEFAULT_N_SIGMA,
     DEFAULT_MANIPULATION_THRESHOLD_DIVISOR,
-    DEFAULT_RESERVE_FACTOR,
     CONSTRAINT_N_SIGMA_MIN,
     CONSTRAINT_N_SIGMA_MAX,
     CONSTRAINT_MANIPULATION_THRESHOLD_DIVISOR_MIN,
     CONSTRAINT_MANIPULATION_THRESHOLD_DIVISOR_MAX,
-    CONSTRAINT_RESERVE_FACTOR_MIN,
-    CONSTRAINT_RESERVE_FACTOR_MAX,
     CONSTRAINT_ANTE_MAX,
     UNISWAP_AVG_WINDOW
 } from "./libraries/constants/Constants.sol";
@@ -70,10 +67,6 @@ contract Factory {
         uint8 nSigma;
         // Described above
         uint8 manipulationThresholdDivisor;
-        // The reserve factor for `market.lender0`, expressed as a reciprocal
-        uint8 reserveFactor0;
-        // The reserve factor for `market.lender1`, expressed as a reciprocal
-        uint8 reserveFactor1;
         // The rate model for `market.lender0`
         IRateModel rateModel0;
         // The rate model for `market.lender1`
@@ -135,14 +128,13 @@ contract Factory {
 
     constructor(
         address governor,
-        address reserve,
         VolatilityOracle oracle,
         BorrowerDeployer borrowerDeployer,
         IRateModel defaultRateModel
     ) {
         GOVERNOR = governor;
         ORACLE = oracle;
-        LENDER_IMPLEMENTATION = address(new Lender(reserve));
+        LENDER_IMPLEMENTATION = address(new Lender());
         _BORROWER_DEPLOYER = borrowerDeployer;
         DEFAULT_RATE_MODEL = defaultRateModel;
     }
@@ -190,8 +182,6 @@ contract Factory {
                 DEFAULT_ANTE,
                 DEFAULT_N_SIGMA,
                 DEFAULT_MANIPULATION_THRESHOLD_DIVISOR,
-                DEFAULT_RESERVE_FACTOR,
-                DEFAULT_RESERVE_FACTOR,
                 DEFAULT_RATE_MODEL,
                 DEFAULT_RATE_MODEL
             ),
@@ -281,13 +271,7 @@ contract Factory {
                 (CONSTRAINT_N_SIGMA_MIN <= config.nSigma && config.nSigma <= CONSTRAINT_N_SIGMA_MAX) &&
                 // manipulationThresholdDivisor: min, max
                 (CONSTRAINT_MANIPULATION_THRESHOLD_DIVISOR_MIN <= config.manipulationThresholdDivisor &&
-                    config.manipulationThresholdDivisor <= CONSTRAINT_MANIPULATION_THRESHOLD_DIVISOR_MAX) &&
-                // reserveFactor0: min, max
-                (CONSTRAINT_RESERVE_FACTOR_MIN <= config.reserveFactor0 &&
-                    config.reserveFactor0 <= CONSTRAINT_RESERVE_FACTOR_MAX) &&
-                // reserveFactor1: min, max
-                (CONSTRAINT_RESERVE_FACTOR_MIN <= config.reserveFactor1 &&
-                    config.reserveFactor1 <= CONSTRAINT_RESERVE_FACTOR_MAX),
+                    config.manipulationThresholdDivisor <= CONSTRAINT_MANIPULATION_THRESHOLD_DIVISOR_MAX),
             "Aloe: constraints"
         );
 
@@ -303,8 +287,8 @@ contract Factory {
         });
 
         Market memory market = getMarket[pool];
-        market.lender0.setRateModelAndReserveFactor(config.rateModel0, config.reserveFactor0);
-        market.lender1.setRateModelAndReserveFactor(config.rateModel1, config.reserveFactor1);
+        market.lender0.setRateModel(config.rateModel0);
+        market.lender1.setRateModel(config.rateModel1);
 
         emit SetMarketConfig(pool, config);
     }

--- a/core/src/Factory.sol
+++ b/core/src/Factory.sol
@@ -129,9 +129,6 @@ contract Factory {
     /// @notice Returns the `Courier` for any given ID
     mapping(uint32 => Courier) public couriers;
 
-    /// @notice Returns whether the given address has enrolled as a courier
-    mapping(address => bool) public isCourier;
-
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
@@ -226,10 +223,6 @@ contract Factory {
     //////////////////////////////////////////////////////////////*/
 
     function claimRewards(Lender[] calldata lenders, address beneficiary) external returns (uint256 earned) {
-        // Couriers cannot claim rewards because the accounting isn't quite correct for them. Specifically, we
-        // save gas by omitting a `Rewards.updateUserState` call for the courier in `Lender._burn`
-        require(!isCourier[msg.sender]);
-
         unchecked {
             uint256 count = lenders.length;
             for (uint256 i = 0; i < count; i++) {
@@ -260,8 +253,6 @@ contract Factory {
         require(couriers[id].cut == 0);
 
         couriers[id] = Courier(msg.sender, cut);
-        isCourier[msg.sender] = true;
-
         emit EnrollCourier(id, msg.sender, cut);
     }
 

--- a/core/src/Ledger.sol
+++ b/core/src/Ledger.sol
@@ -5,7 +5,6 @@ import {ImmutableArgs} from "clones-with-immutable-args/ImmutableArgs.sol";
 import {IERC165} from "openzeppelin-contracts/contracts/interfaces/IERC165.sol";
 import {IERC2612} from "openzeppelin-contracts/contracts/interfaces/IERC2612.sol";
 import {IERC4626} from "openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
-import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {FixedPointMathLib as SoladyMath} from "solady/utils/FixedPointMathLib.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {ERC20} from "solmate/tokens/ERC20.sol";
@@ -31,13 +30,10 @@ contract Ledger {
 
     Factory public immutable FACTORY;
 
-    address public immutable RESERVE;
-
     /*//////////////////////////////////////////////////////////////
                              LENDER STORAGE
     //////////////////////////////////////////////////////////////*/
 
-    /// @dev Doesn't include reserve inflation. If you want that, use `stats()`
     uint112 public totalSupply;
 
     /// @dev Used in lieu of `asset.balanceOf` to prevent inflation attacks
@@ -80,16 +76,12 @@ contract Ledger {
      */
     IRateModel public rateModel;
 
-    /// @dev The portion of interest that accrues to the `RESERVE`. Expressed as a reciprocal, e.g. 16 → 6.25%
-    uint8 public reserveFactor;
-
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(address reserve) {
+    constructor() {
         FACTORY = Factory(msg.sender);
-        RESERVE = reserve;
     }
 
     /// @notice Returns true if this contract implements the interface defined by `interfaceId`
@@ -143,17 +135,17 @@ contract Ledger {
      * @return The updated `borrowIndex`
      * @return The sum of all banknote balances, in underlying units (i.e. `totalAssets`)
      * @return The sum of all outstanding debts, in underlying units
-     * @return The sum of all banknote balances. Will differ from `totalSupply` due to reserves inflation
+     * @return The sum of all banknote balances
      */
     function stats() external view returns (uint72, uint256, uint256, uint256) {
-        (Cache memory cache, uint256 inventory, uint256 newTotalSupply) = _previewInterest(_getCache());
+        (Cache memory cache, uint256 inventory) = _previewInterest(_getCache());
 
         unchecked {
             return (
                 uint72(cache.borrowIndex),
                 inventory,
                 (cache.borrowBase * cache.borrowIndex) / BORROWS_SCALER,
-                newTotalSupply
+                cache.totalSupply
             );
         }
     }
@@ -192,8 +184,14 @@ contract Ledger {
      * @dev Because of the fees, ∑underlyingBalances != totalAssets
      */
     function underlyingBalance(address account) external view returns (uint256) {
-        (, uint256 inventory, uint256 newTotalSupply) = _previewInterest(_getCache());
-        return _convertToAssets(_nominalShares(account, inventory, newTotalSupply), inventory, newTotalSupply, false);
+        (Cache memory cache, uint256 inventory) = _previewInterest(_getCache());
+        return
+            _convertToAssets(
+                _nominalShares(account, inventory, cache.totalSupply),
+                inventory,
+                cache.totalSupply,
+                false
+            );
     }
 
     /**
@@ -217,7 +215,7 @@ contract Ledger {
     function borrowBalance(address account) external view returns (uint256) {
         uint256 b = borrows[account];
 
-        (Cache memory cache, , ) = _previewInterest(_getCache());
+        (Cache memory cache, ) = _previewInterest(_getCache());
         unchecked {
             return b > 1 ? ((b - 1) * cache.borrowIndex).unsafeDivUp(BORROWS_SCALER) : 0;
         }
@@ -236,24 +234,20 @@ contract Ledger {
                            ERC4626 ACCOUNTING
     //////////////////////////////////////////////////////////////*/
 
-    /**
-     * @notice The total amount of `asset` under management
-     * @dev `convertToShares(totalAssets()) != totalSupply()` due to reserves inflation. If you need
-     * the up-to-date supply, use `stats()`
-     */
+    /// @notice The total amount of `asset` under management
     function totalAssets() external view returns (uint256) {
-        (, uint256 inventory, ) = _previewInterest(_getCache());
+        (, uint256 inventory) = _previewInterest(_getCache());
         return inventory;
     }
 
     function convertToShares(uint256 assets) public view returns (uint256) {
-        (, uint256 inventory, uint256 newTotalSupply) = _previewInterest(_getCache());
-        return _convertToShares(assets, inventory, newTotalSupply, /* roundUp: */ false);
+        (Cache memory cache, uint256 inventory) = _previewInterest(_getCache());
+        return _convertToShares(assets, inventory, cache.totalSupply, /* roundUp: */ false);
     }
 
     function convertToAssets(uint256 shares) public view returns (uint256) {
-        (, uint256 inventory, uint256 newTotalSupply) = _previewInterest(_getCache());
-        return _convertToAssets(shares, inventory, newTotalSupply, /* roundUp: */ false);
+        (Cache memory cache, uint256 inventory) = _previewInterest(_getCache());
+        return _convertToAssets(shares, inventory, cache.totalSupply, /* roundUp: */ false);
     }
 
     function previewDeposit(uint256 assets) public view returns (uint256) {
@@ -261,8 +255,8 @@ contract Ledger {
     }
 
     function previewMint(uint256 shares) public view returns (uint256) {
-        (, uint256 inventory, uint256 newTotalSupply) = _previewInterest(_getCache());
-        return _convertToAssets(shares, inventory, newTotalSupply, /* roundUp: */ true);
+        (Cache memory cache, uint256 inventory) = _previewInterest(_getCache());
+        return _convertToAssets(shares, inventory, cache.totalSupply, /* roundUp: */ true);
     }
 
     function previewRedeem(uint256 shares) public view returns (uint256) {
@@ -270,8 +264,8 @@ contract Ledger {
     }
 
     function previewWithdraw(uint256 assets) public view returns (uint256) {
-        (, uint256 inventory, uint256 newTotalSupply) = _previewInterest(_getCache());
-        return _convertToShares(assets, inventory, newTotalSupply, /* roundUp: */ true);
+        (Cache memory cache, uint256 inventory) = _previewInterest(_getCache());
+        return _convertToShares(assets, inventory, cache.totalSupply, /* roundUp: */ true);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -309,10 +303,10 @@ contract Ledger {
      * @return The maximum number of Vault shares that can be redeemed
      */
     function maxRedeem(address owner) public view returns (uint256) {
-        (Cache memory cache, uint256 inventory, uint256 newTotalSupply) = _previewInterest(_getCache());
+        (Cache memory cache, uint256 inventory) = _previewInterest(_getCache());
 
-        uint256 a = _nominalShares(owner, inventory, newTotalSupply);
-        uint256 b = _convertToShares(cache.lastBalance, inventory, newTotalSupply, false);
+        uint256 a = _nominalShares(owner, inventory, cache.totalSupply);
+        uint256 b = _convertToShares(cache.lastBalance, inventory, cache.totalSupply, false);
 
         return a < b ? a : b;
     }
@@ -335,34 +329,25 @@ contract Ledger {
      * @dev Accrues interest up to the current `block.timestamp`. Updates and returns `cache`, but doesn't write
      * anything to storage.
      */
-    function _previewInterest(Cache memory cache) internal view returns (Cache memory, uint256, uint256) {
+    function _previewInterest(Cache memory cache) internal view returns (Cache memory, uint256) {
         unchecked {
-            // Guard against reentrancy
-            require(cache.lastAccrualTime != 0, "Aloe: locked");
-
             uint256 oldBorrows = (cache.borrowBase * cache.borrowIndex) / BORROWS_SCALER;
             uint256 oldInventory = cache.lastBalance + oldBorrows;
 
             if (cache.lastAccrualTime == block.timestamp || oldBorrows == 0) {
-                return (cache, oldInventory, cache.totalSupply);
+                return (cache, oldInventory);
             }
 
-            // sload `reserveFactor` and `rateModel` at the same time since they're in the same slot
-            uint8 rf = reserveFactor;
             uint256 accrualFactor = rateModel.getAccrualFactor({
                 utilization: (1e18 * oldBorrows) / oldInventory,
                 dt: block.timestamp - cache.lastAccrualTime
             });
 
             cache.borrowIndex = SoladyMath.min((cache.borrowIndex * accrualFactor) / ONE, type(uint72).max);
-            cache.lastAccrualTime = 0; // 0 in storage means locked to reentrancy; 0 in `cache` means `borrowIndex` was updated
+            cache.lastAccrualTime = 0; // 0 indicates `borrowIndex` was updated
 
             uint256 newInventory = cache.lastBalance + (cache.borrowBase * cache.borrowIndex) / BORROWS_SCALER;
-            uint256 newTotalSupply = SoladyMath.min(
-                Math.mulDiv(cache.totalSupply, newInventory, newInventory - (newInventory - oldInventory) / rf),
-                type(uint112).max
-            );
-            return (cache, newInventory, newTotalSupply);
+            return (cache, newInventory);
         }
     }
 
@@ -411,7 +396,7 @@ contract Ledger {
         }
     }
 
-    function _getCache() private view returns (Cache memory) {
+    function _getCache() internal view returns (Cache memory) {
         return Cache(totalSupply, lastBalance, lastAccrualTime, borrowBase, borrowIndex);
     }
 }

--- a/core/src/Lender.sol
+++ b/core/src/Lender.sol
@@ -129,7 +129,8 @@ contract Lender is Ledger {
         }
 
         // Accrue interest
-        (Cache memory cache, uint256 inventory) = _previewInterest(_getCache());
+        Cache memory cache = _previewInterest(_getCache());
+        uint256 inventory = _inventory(cache);
 
         // Convert `amount` to `shares`
         shares = _convertToShares(amount, inventory, cache.totalSupply, /* roundUp: */ false);
@@ -182,7 +183,8 @@ contract Lender is Ledger {
         }
 
         // Accrue interest
-        (Cache memory cache, uint256 inventory) = _previewInterest(_getCache());
+        Cache memory cache = _previewInterest(_getCache());
+        uint256 inventory = _inventory(cache);
 
         // Convert `shares` to `amount`
         amount = _convertToAssets(shares, inventory, cache.totalSupply, /* roundUp: */ false);
@@ -217,7 +219,7 @@ contract Lender is Ledger {
         require(b != 0, "Aloe: not a borrower");
 
         // Accrue interest
-        (Cache memory cache, ) = _previewInterest(_getCache());
+        Cache memory cache = _previewInterest(_getCache());
 
         unchecked {
             // Convert `amount` to `units`
@@ -257,7 +259,7 @@ contract Lender is Ledger {
         uint256 b = borrows[beneficiary];
 
         // Accrue interest
-        (Cache memory cache, ) = _previewInterest(_getCache());
+        Cache memory cache = _previewInterest(_getCache());
 
         unchecked {
             // Convert `amount` to `units`
@@ -286,7 +288,7 @@ contract Lender is Ledger {
     }
 
     function accrueInterest() external returns (uint72) {
-        (Cache memory cache, ) = _previewInterest(_getCache());
+        Cache memory cache = _previewInterest(_getCache());
         _save(cache, /* didChangeBorrowBase: */ false);
         return uint72(cache.borrowIndex);
     }

--- a/core/src/Lender.sol
+++ b/core/src/Lender.sol
@@ -510,15 +510,12 @@ contract Lender is Ledger {
                     // Compute portion of fee to pay out during this burn.
                     fee = (fee * shares) / balance;
 
-                    // Send `fee` from `from` to `courier.wallet`.
+                    // Send `fee` from `from` to `courier`.
                     // NOTE: We skip principle update on courier, so if couriers credit
                     // each other, 100% of `fee` is treated as profit and will pass through
                     // to the next courier.
-                    // NOTE: We skip rewards update on the courier. This means accounting isn't
-                    // accurate for them, so they *should not* be allowed to claim rewards. This
-                    // slightly reduces the effective overall rewards rate.
                     data -= fee;
-                    balances[courier] += fee;
+                    Rewards.updateUserState(s, a, courier, (balances[courier] += fee) - fee);
                     emit Transfer(from, courier, fee);
                 }
 

--- a/core/src/libraries/constants/Constants.sol
+++ b/core/src/libraries/constants/Constants.sol
@@ -45,10 +45,6 @@ uint8 constant DEFAULT_N_SIGMA = 50;
 /// \frac{log_{1.0001}\left( \frac{1}{\text{LTV}} \right)}{\text{MANIPULATION_THRESHOLD_DIVISOR}} \\)
 uint8 constant DEFAULT_MANIPULATION_THRESHOLD_DIVISOR = 12;
 
-/// @dev The default portion of interest that will accrue to a `Lender`'s `RESERVE` address.
-/// Expressed as a reciprocal, e.g. 16 → 6.25%
-uint8 constant DEFAULT_RESERVE_FACTOR = 16;
-
 /*//////////////////////////////////////////////////////////////
                         GOVERNANCE CONSTRAINTS
 //////////////////////////////////////////////////////////////*/
@@ -66,12 +62,6 @@ uint8 constant CONSTRAINT_MANIPULATION_THRESHOLD_DIVISOR_MIN = 10;
 
 /// @dev The maximum value of the `manipulationThresholdDivisor`, described above
 uint8 constant CONSTRAINT_MANIPULATION_THRESHOLD_DIVISOR_MAX = 16;
-
-/// @dev The lower bound on what any `Lender`'s reserve factor can be. Expressed as reciprocal, e.g. 4 → 25%
-uint8 constant CONSTRAINT_RESERVE_FACTOR_MIN = 4;
-
-/// @dev The upper bound on what any `Lender`'s reserve factor can be. Expressed as reciprocal, e.g. 20 → 5%
-uint8 constant CONSTRAINT_RESERVE_FACTOR_MAX = 20;
 
 /// @dev The maximum amount of Ether that `Borrower`s can be required to post before taking on debt
 uint216 constant CONSTRAINT_ANTE_MAX = 0.5 ether;

--- a/core/test/Borrower.t.sol
+++ b/core/test/Borrower.t.sol
@@ -75,7 +75,7 @@ contract BorrowerTest is Test, IManager, IUniswapV3SwapCallback {
 
         VolatilityOracle oracle = new VolatilityOracle();
         RateModel rateModel = new RateModel();
-        factory = new FatFactory(address(0), address(0), oracle, rateModel);
+        factory = new FatFactory(address(0), oracle, rateModel);
 
         factory.createMarket(pool);
         (lender0, lender1, impl) = factory.getMarket(pool);

--- a/core/test/Factory.t.sol
+++ b/core/test/Factory.t.sol
@@ -101,7 +101,6 @@ contract FactoryTest is Test {
         emit EnrollCourier(id, address(this), cut);
         factory.enrollCourier(id, cut);
 
-        assertTrue(factory.isCourier(address(this)));
         (address courier, uint16 cutRec) = factory.couriers(id);
         assertEq(courier, address(this));
         assertEq(cutRec, cut);
@@ -114,13 +113,6 @@ contract FactoryTest is Test {
         Lender[] memory lenders = new Lender[](2);
         lenders[0] = lender0;
         lenders[1] = lender1;
-
-        // Couriers cannot claim rewards
-        vm.prank(address(6789));
-        factory.enrollCourier(1, 5000);
-        vm.prank(address(6789));
-        vm.expectRevert(bytes(""));
-        factory.claimRewards(lenders, address(6789));
 
         // Set rewards token
         vm.prank(factory.GOVERNOR());

--- a/core/test/Factory.t.sol
+++ b/core/test/Factory.t.sol
@@ -8,13 +8,10 @@ import {
     DEFAULT_ANTE,
     DEFAULT_N_SIGMA,
     DEFAULT_MANIPULATION_THRESHOLD_DIVISOR,
-    DEFAULT_RESERVE_FACTOR,
     CONSTRAINT_N_SIGMA_MIN,
     CONSTRAINT_N_SIGMA_MAX,
     CONSTRAINT_MANIPULATION_THRESHOLD_DIVISOR_MIN,
     CONSTRAINT_MANIPULATION_THRESHOLD_DIVISOR_MAX,
-    CONSTRAINT_RESERVE_FACTOR_MIN,
-    CONSTRAINT_RESERVE_FACTOR_MAX,
     CONSTRAINT_ANTE_MAX,
     UNISWAP_AVG_WINDOW
 } from "src/libraries/constants/Constants.sol";
@@ -41,7 +38,7 @@ contract FactoryTest is Test {
     function setUp() public {
         vm.createSelectFork(vm.rpcUrl("mainnet"), 15_348_451);
 
-        factory = new FatFactory(address(12345), address(0), new VolatilityOracle(), new RateModel());
+        factory = new FatFactory(address(12345), new VolatilityOracle(), new RateModel());
         rewardsToken = new MockERC20("Mock Token", "MOCK", 18);
     }
 
@@ -55,8 +52,6 @@ contract FactoryTest is Test {
         assertEq(factory.peer(address(lender1)), address(lender0));
         assertEq(address(lender0.rateModel()), address(factory.DEFAULT_RATE_MODEL()));
         assertEq(address(lender1.rateModel()), address(factory.DEFAULT_RATE_MODEL()));
-        assertEq(lender0.reserveFactor(), DEFAULT_RESERVE_FACTOR);
-        assertEq(lender1.reserveFactor(), DEFAULT_RESERVE_FACTOR);
 
         vm.expectRevert(bytes(""));
         lender0.initialize();

--- a/core/test/Lender.t.sol
+++ b/core/test/Lender.t.sol
@@ -110,10 +110,6 @@ contract LenderTest is Test {
             FixedPointMathLib.rpow(ONE + yieldPerSecond, 13, ONE),
             1e12
         );
-        uint256 interest = newInventory - 2e18;
-        uint256 reserves = interest / lender.reserveFactor();
-
-        uint256 epsilon = 2;
 
         // Initially, the `lender` holds 1e18 and has lent out 1e18
         assertEqDecimal(lender.totalAssets(), 2e18, 18);
@@ -127,16 +123,11 @@ contract LenderTest is Test {
         lender.accrueInterest();
         // Both `totalAssets` and `underlyingBalanceStored` should have updated now
         assertEqDecimal(lender.totalAssets(), newInventory, 18);
-        assertLeDecimal(
-            stdMath.delta(lender.underlyingBalanceStored(address(this)), newInventory - reserves),
-            epsilon,
-            18
-        );
+        assertEqDecimal(lender.underlyingBalanceStored(address(this)), newInventory, 18);
         // Make sure `borrowIndex` is just as precise as `yieldPerSecond` and `accrualFactor`
         if (yieldPerSecond > 0) assertGt(lender.borrowIndex(), 1e12);
 
         assertEq(lender.lastAccrualTime(), block.timestamp);
-        assertLeDecimal(stdMath.delta(lender.underlyingBalance(lender.RESERVE()), reserves), epsilon, 18);
 
         vm.clearMockedCalls();
     }
@@ -268,8 +259,8 @@ contract LenderTest is Test {
         assertEq(asset.balanceOf(jim), 10e6);
         assertEq(lender.borrowBalance(jim), 10000058);
 
-        assertEq(lender.underlyingBalance(alice), 100000050);
-        assertEq(lender.underlyingBalanceStored(alice), 100000050);
+        assertEq(lender.underlyingBalance(alice), 100000057);
+        assertEq(lender.underlyingBalanceStored(alice), 100000057);
     }
 
     function test_fuzz_borrow(uint256 amount, address recipient, address caller) public {

--- a/core/test/LenderReferrals.t.sol
+++ b/core/test/LenderReferrals.t.sol
@@ -103,7 +103,7 @@ contract LenderReferralsTest is Test {
 
     function test_canCreditCourierWithPermission(uint32 id, address wallet, uint16 cut, address account) public {
         (id, wallet, cut) = _enroll(id, wallet, cut);
-        vm.assume(wallet != account && account != lender.RESERVE());
+        vm.assume(wallet != account);
 
         vm.prank(account);
         lender.approve(address(this), 1);
@@ -146,7 +146,6 @@ contract LenderReferralsTest is Test {
         address account
     ) public {
         vm.assume(wallet != account);
-        vm.assume(account != lender.RESERVE());
         (id, wallet, cut) = _enroll(id, wallet, cut);
 
         vm.prank(account);
@@ -170,7 +169,7 @@ contract LenderReferralsTest is Test {
         (id, wallet, cut) = _enroll(id, wallet, cut);
         address to = caller;
 
-        if (to == wallet || to == lender.RESERVE()) {
+        if (to == wallet) {
             vm.prank(to);
             vm.expectRevert(bytes("Aloe: courier"));
             lender.deposit(amount, to, id);
@@ -220,7 +219,7 @@ contract LenderReferralsTest is Test {
 
         if (to == wallet || to == address(lender)) return;
 
-        if (to == wallet || to == lender.RESERVE()) {
+        if (to == wallet) {
             vm.prank(to);
             vm.expectRevert(bytes("Aloe: courier"));
             lender.deposit(amount, to, id);

--- a/core/test/Liquidator.t.sol
+++ b/core/test/Liquidator.t.sol
@@ -29,7 +29,6 @@ contract LiquidatorTest is Test, IManager, ILiquidator {
 
         Factory factory = new FatFactory(
             address(0),
-            address(0),
             VolatilityOracle(address(new VolatilityOracleMock())),
             new RateModel()
         );

--- a/core/test/Utils.sol
+++ b/core/test/Utils.sol
@@ -17,17 +17,16 @@ import {VolatilityOracle} from "src/VolatilityOracle.sol";
 contract FatFactory is Factory {
     constructor(
         address governor,
-        address reserve,
         VolatilityOracle oracle,
         IRateModel defaultRateModel
-    ) Factory(governor, reserve, oracle, new BorrowerDeployer(), defaultRateModel) {}
+    ) Factory(governor, oracle, new BorrowerDeployer(), defaultRateModel) {}
 }
 
 contract FactoryForLenderTests is FatFactory {
     constructor(
         RateModel rateModel,
         ERC20 rewardsToken_
-    ) FatFactory(address(0), address(this), VolatilityOracle(address(0)), rateModel) {
+    ) FatFactory(address(0), VolatilityOracle(address(0)), rateModel) {
         rewardsToken = rewardsToken_;
     }
 
@@ -36,7 +35,7 @@ contract FactoryForLenderTests is FatFactory {
         peer[proxy] = address(1);
 
         Lender(proxy).initialize();
-        Lender(proxy).setRateModelAndReserveFactor(DEFAULT_RATE_MODEL, 8);
+        Lender(proxy).setRateModel(DEFAULT_RATE_MODEL);
         return Lender(proxy);
     }
 }

--- a/core/test/gas/BorrowerGas.t.sol
+++ b/core/test/gas/BorrowerGas.t.sol
@@ -29,7 +29,6 @@ contract BorrowerGasTest is Test, IManager {
 
         Factory factory = new FatFactory(
             address(0),
-            address(0),
             VolatilityOracle(address(new VolatilityOracleMock())),
             new RateModel()
         );

--- a/core/test/gas/FactoryGas.t.sol
+++ b/core/test/gas/FactoryGas.t.sol
@@ -21,7 +21,6 @@ contract FactoryGasTest is Test {
 
         factory = new FatFactory(
             address(0),
-            address(0),
             new VolatilityOracle(),
             new RateModel()
         );

--- a/core/test/gas/LiquidatorGas.t.sol
+++ b/core/test/gas/LiquidatorGas.t.sol
@@ -29,7 +29,6 @@ contract LiquidatorGasTest is Test, IManager, ILiquidator {
 
         Factory factory = new FatFactory(
             address(0),
-            address(0),
             VolatilityOracle(address(new VolatilityOracleMock())),
             new RateModel()
         );

--- a/core/test/invariants/ERC4626Invariants.t.sol
+++ b/core/test/invariants/ERC4626Invariants.t.sol
@@ -32,14 +32,14 @@ contract ERC4626InvariantsTest is Test {
     function setUp() public {
         {
             asset = new MockERC20("Token", "TKN", 18); // TODO: replace 18 with an env var
-            address lenderImplementation = address(new Lender(address(2)));
+            address lenderImplementation = address(new Lender());
             Lender lender = Lender(ClonesWithImmutableArgs.clone(
                 lenderImplementation,
                 abi.encodePacked(address(asset))
             ));
             RateModel rateModel = new RateModel();
             lender.initialize();
-            lender.setRateModelAndReserveFactor(rateModel, 8); // TODO: replace 8 with an env var
+            lender.setRateModel(rateModel);
 
             vault = ERC4626(address(lender));
             vaultHarness = new ERC4626Harness(lender);


### PR DESCRIPTION
Addresses (by virtue of removing the `RESERVE` entirely)
- https://github.com/sherlock-audit/2023-10-aloe-judging/issues/49

Future PR will use the `erase` method in `Borrower`